### PR TITLE
feat: kakao-chat-ci 적용

### DIFF
--- a/.github/workflows/kakao_ci.yml
+++ b/.github/workflows/kakao_ci.yml
@@ -1,4 +1,5 @@
 name: BE CI
+run-name: Deploy by @${{ github.actor }} 
 
 on: 
     push: 
@@ -11,19 +12,39 @@ on:
         types: [submitted]
 
 jobs:
-  build-and-notify:
-    runs-on: ubuntu-latest
+    build-and-notify:
+        runs-on: self-hosted
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+            - name: Determine event type and trigger action at macOS
+              if: runner.os == 'macOS' 
+              run: |
+                if [ ${{github.event_name}} == 'push' ]; then
+                  echo "TITLE=[${{github.actor}}]_${{ github.event_name }}" >> $GITHUB_OUTPUT
+                  echo "DESC='$(echo '${{ github.event.head_commit.message }}' | awk '{printf "%s", $0}')'" >> $GITHUB_OUTPUT
+                elif [ ${{github.event_name}} == 'pull_request' ]; then
+                  echo "TITLE='[${{github.actor}}]_${{ github.event_name }}'" >> $GITHUB_OUTPUT
+                  echo "DESC='$(echo '${{ github.event.pull_request.title }}' | awk '{printf "%s", $0}')'" >> $GITHUB_OUTPUT
+                elif [ ${{github.event_name}} == 'pull_request_review' ]; then
+                  echo "TITLE='[${{github.actor}}]_${{ github.event_name }}'" >> $GITHUB_OUTPUT
+                  echo "DESC='$(echo '${{ github.event.pull_request.title }}' | awk '{printf "%s", $0}')'" >> $GITHUB_OUTPUT
+                fi
+              id: determine_event_type_mac
 
-      - name: Send KakaoTalk notification
-        uses: psychology50/kakao-chat-ci@main
-        with:
-          KAKAO_CLIENT: ${{ secrets.KAKAO_CLIENT }}
-          KAKAO_EMAIL: ${{ secrets.KAKAO_EMAIL }}
-          KAKAO_PASSWORD: ${{ secrets.KAKAO_PASSWORD }}
-          KAKAO_TEMPLATE_ID: 97232
-          KAKAO_SENDER_TEMPLATE_ID: 97280
-          KAKAO_REDIRECT_URL: http://localhost:3000/oauth/kakao/callback
+            - name: run kakao-chat
+              if: runner.os == 'macOS'
+              uses: psychology50/kakao-chat-ci@main
+              env:
+                KAKAO_CLIENT: ${{ secrets.KAKAO_CLIENT }}
+                KAKAO_EMAIL: ${{ secrets.KAKAO_EMAIL }}
+                KAKAO_PASSWORD: ${{ secrets.KAKAO_PASSWORD }}
+                KAKAO_TEMPLATE_ID: 97232
+                KAKAO_SENDER_TEMPLATE_ID: 97280
+                KAKAO_REDIRECT_URL: http://localhost:3000/oauth/kakao/callback
+                TITLE: ${{ steps.determine_event_type_mac.outputs.TITLE }}
+                DESC: ${{ steps.determine_event_type_mac.outputs.DESC }}
+
+                
+

--- a/.github/workflows/kakao_ci.yml
+++ b/.github/workflows/kakao_ci.yml
@@ -1,12 +1,14 @@
 name: BE CI
 
-on:
-  workflow_dispatch:
-  
-  push:
-    branches:
-      - main
-      - develop
+on: 
+    push: 
+        branches: 
+            - main
+            - develop
+    pull_request:
+        types: [review_requested, opened, reopened, ready_for_review]
+    pull_request_review:
+        types: [submitted]
 
 jobs:
   build-and-notify:
@@ -18,3 +20,10 @@ jobs:
 
       - name: Send KakaoTalk notification
         uses: psychology50/kakao-chat-ci@main
+        with:
+          KAKAO_CLIENT: ${{ secrets.KAKAO_CLIENT }}
+          KAKAO_EMAIL: ${{ secrets.KAKAO_EMAIL }}
+          KAKAO_PASSWORD: ${{ secrets.KAKAO_PASSWORD }}
+          KAKAO_TEMPLATE_ID: 97232
+          KAKAO_SENDER_TEMPLATE_ID: 97280
+          KAKAO_REDIRECT_URL: http://localhost:3000/oauth/kakao/callback

--- a/.github/workflows/kakao_ci.yml
+++ b/.github/workflows/kakao_ci.yml
@@ -17,10 +17,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Send KakaoTalk notification
-        uses: Alfex4936/kakaotalk-ci-action@main
-        # if: failure()
-        with:
-          kakao_access_token: ${{ secrets.KAKAO_ACCESS_TOKEN }}
-          function_name: send_to_me_custom
-          template_id: "97232"
-          template_args: '{"title": "BE push", "desc": "확인해주세요!"}'
+        uses: psychology50/kakao-chat-ci@main


### PR DESCRIPTION
## 작업 이유
카카오톡을 이용한 CI 기능 구축. 
이벤트 감지 → 카카오 알림 전송

## 작업 사항
- 이벤트 발생 조건
   - main 또는 develop 브랜치에 push 이벤트가 발생하는 경우
   - pull_request가 열린 경우 (단, draft PR은 제외)
   - pull_request_review 이벤트가 발생한 경우 (submitted, edited, dismissed)
- 실행
   - push 이벤트가 발생한 경우:
      - TITLE: GitHub 사용자 이름 (커밋한 유저)
      - DESC: 커밋 메시지
   - pull_request 이벤트가 열린 경우:
      - TITLE: PR을 연 사용자의 로그인 이름
      - DESC: PR 제목
   - pull_request_review 이벤트가 발생한 경우:
      - TITLE: 리뷰어의 로그인 이름
      - DESC: 리뷰 내용
   - pull_request_review 이벤트가 발생하고, 리뷰어가 승인한 경우:
      - TITLE: 리뷰어의 로그인 이름
      - DESC: 승인한 PR 제목

## 이슈 연결
close #13