### PR TITLE
🐛 ID/PW 전화 번호 인증 시, 전화번호 존재 여부 판단 로직 추가

### DIFF
--- a/src/main/java/com/kcy/fitapet/domain/member/exception/AccountErrorCode.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/exception/AccountErrorCode.java
@@ -26,6 +26,7 @@ public enum AccountErrorCode implements StatusCode {
 
     /* 404 */
     NOT_FOUND_MEMBER_ERROR(NOT_FOUND, "존재하지 않는 회원입니다."),
+    NOT_FOUND_PHONE_ERROR(NOT_FOUND, "존재하지 않는 전화번호입니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 작업 이유
- 서비스에 등록되어 있지 않은 전화번호로 ID/PW를 위한 인증 코드 발급이 진행되는 문제점
- 인증 코드 발급 전에 DB에 해당 전화번호로 가입한 유저가 존재하는 지 탐색

## 작업 사항
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/e762fcd0-a561-4146-b7c2-025418a27bfd)


## 이슈 연결
close #40