### PR TITLE
🔧 REST 원칙 설계 및 Method Security 방식으로 변경

### DIFF
--- a/src/main/java/com/kcy/fitapet/domain/member/api/AuthApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/api/AuthApi.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
@@ -64,6 +65,7 @@ public class AuthApi {
             @ApiResponse(responseCode = "4xx", description = "에러", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @PostMapping("/register")
+    @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> signUp(@RequestHeader("Authorization") @NotBlank String accessToken, @RequestBody @Valid SignUpReq dto) {
         Map<String, String> tokens = memberAuthService.register(accessToken, dto);
         return getResponseEntity(tokens);
@@ -80,6 +82,7 @@ public class AuthApi {
             @ApiResponse(responseCode = "4xx", description = "에러", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @PostMapping("/register-sms")
+    @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> registerSmsAuthorization(
             @RequestParam(value = "code", required = false) String code,
             @RequestBody @Valid SmsReq dto) {
@@ -108,6 +111,7 @@ public class AuthApi {
             @ApiResponse(responseCode = "4xx", description = "에러", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @PostMapping("/search-sms")
+    @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> searchSmsAuthorization(
         @RequestParam(value = "type") SmsPrefix type,
         @RequestParam(value = "code", required = false) String code,
@@ -131,6 +135,7 @@ public class AuthApi {
             @ApiResponse(responseCode = "4xx", description = "에러", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @PostMapping("/login")
+    @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> signIn(@RequestHeader(value = "Authorization", required = false) String accessToken, @RequestBody @Valid SignInReq dto) {
         if (accessToken != null)
             throw new GlobalErrorException(ErrorCode.ALREADY_LOGIN_USER);
@@ -149,6 +154,7 @@ public class AuthApi {
             @ApiResponse(responseCode = "4xx", description = "에러", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @GetMapping("/logout")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> signOut(
             @AccessTokenInfo AccessToken accessToken,
             @CookieValue(value = "refreshToken", required = false) @Valid String refreshToken,

--- a/src/main/java/com/kcy/fitapet/domain/member/service/component/MemberAccountService.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/service/component/MemberAccountService.java
@@ -12,6 +12,7 @@ import com.kcy.fitapet.domain.member.type.MemberAttrType;
 import com.kcy.fitapet.domain.notification.type.NotificationType;
 import com.kcy.fitapet.global.common.redis.sms.SmsCertificationService;
 import com.kcy.fitapet.global.common.redis.sms.SmsPrefix;
+import com.kcy.fitapet.global.common.response.code.ErrorCode;
 import com.kcy.fitapet.global.common.response.code.StatusCode;
 import com.kcy.fitapet.global.common.response.exception.GlobalErrorException;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,7 @@ public class MemberAccountService {
     private final PasswordEncoder bCryptPasswordEncoder;
 
     @Transactional(readOnly = true)
-    public AccountProfileRes getProfile(Long userId) {
+    public AccountProfileRes getProfile(Long requestId, Long userId) {
         Member member = memberSearchService.findById(userId);
         return AccountProfileRes.from(member);
     }
@@ -42,7 +43,7 @@ public class MemberAccountService {
     }
 
     @Transactional
-    public void updateProfile(Long userId, ProfilePatchReq req, MemberAttrType type) {
+    public void updateProfile(Long requestId, Long userId, ProfilePatchReq req, MemberAttrType type) {
         Member member = memberSearchService.findById(userId);
 
         if (type == MemberAttrType.NAME) {
@@ -75,7 +76,7 @@ public class MemberAccountService {
     }
 
     @Transactional
-    public void updateNotification(Long userId, NotificationType type) {
+    public void updateNotification(Long requestId, Long userId, NotificationType type) {
         Member member = memberSearchService.findById(userId);
         member.updateNotificationFromType(type);
     }
@@ -118,11 +119,11 @@ public class MemberAccountService {
     }
 
     /**
-     * redis에 해당 전화번호에 대한 정보가 저장되어 있는 지 확인하고, <br/>
+     * in-memory에 해당 전화번호에 대한 정보가 저장되어 있는 지 확인하고, <br/>
      * {"phone:"인증번호"} 형태의 인증번호가 일치함을 확인
-     * @param phone
-     * @param code
-     * @param prefix
+     * @param phone : 전화번호
+     * @param code : 인증번호
+     * @param prefix : 인증번호 타입
      */
     private void validatePhone(String phone, String code, SmsPrefix prefix) {
         if (!smsCertificationService.existsCertificationNumber(phone, prefix)) {

--- a/src/main/java/com/kcy/fitapet/domain/oauth2/api/OAuthApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/oauth2/api/OAuthApi.java
@@ -1,0 +1,15 @@
+package com.kcy.fitapet.domain.oauth2.api;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "OAuth API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth/oauth")
+@Slf4j
+public class OAuthApi {
+}

--- a/src/main/java/com/kcy/fitapet/global/common/response/SuccessResponse.java
+++ b/src/main/java/com/kcy/fitapet/global/common/response/SuccessResponse.java
@@ -20,7 +20,7 @@ import java.util.Map;
 public class SuccessResponse<T> {
     @Schema(description = "응답 상태", defaultValue = "success")
     private final String status = "success";
-    @Schema(description = "응답 코드", example = "200")
+    @Schema(description = "응답 코드", example = "data or no_content")
     private Map<String, T> data;
 
     @Builder

--- a/src/main/java/com/kcy/fitapet/global/common/response/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kcy/fitapet/global/common/response/handler/GlobalExceptionHandler.java
@@ -31,7 +31,6 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 public class GlobalExceptionHandler {
     /**
      * API 호출 시 서버에서 발생시킨 전역 예외를 처리하는 메서드
-     * @param e GlobalErrorException
      * @return ResponseEntity<ErrorResponse>
      */
     @ExceptionHandler(GlobalErrorException.class)
@@ -43,7 +42,6 @@ public class GlobalExceptionHandler {
 
     /**
      * API 호출 시 인증 관련 예외를 처리하는 메서드
-     * @param e AuthErrorException
      * @return ResponseEntity<ErrorResponse>
      */
     @ExceptionHandler(AuthErrorException.class)
@@ -55,7 +53,6 @@ public class GlobalExceptionHandler {
 
     /**
      * API 호출 시 인가 관련 예외를 처리하는 메서드
-     * @param e AccessDeniedException
      * @return ResponseEntity<ErrorResponse>
      */
     @ResponseStatus(HttpStatus.FORBIDDEN)
@@ -67,7 +64,6 @@ public class GlobalExceptionHandler {
 
     /**
      * API 호출 시 객체 혹은 파라미터 데이터 값이 유효하지 않은 경우
-     * @param e MethodArgumentNotValidException
      * @return ResponseEntity<FailureResponse>
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -78,6 +74,9 @@ public class GlobalExceptionHandler {
         return ResponseEntity.unprocessableEntity().body(response);
     }
 
+    /**
+     * API 호출 시 객체 혹은 파라미터 데이터 값이 유효하지 않은 경우
+     */
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     protected ResponseEntity<FailureResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
         log.warn("handleMethodArgumentTypeMismatchException: {}", e.getMessage());
@@ -97,7 +96,6 @@ public class GlobalExceptionHandler {
 
     /**
      * API 호출 시 'Header' 내에 데이터 값이 유효하지 않은 경우
-     * @param e MissingRequestHeaderException
      * @return ResponseEntity<FailureResponse>
      */
     @ExceptionHandler(MissingRequestHeaderException.class)
@@ -109,7 +107,6 @@ public class GlobalExceptionHandler {
 
     /**
      * API 호출 시 'BODY' 내에 데이터 값이 존재하지 않은 경우
-     * @param e HttpMessageNotReadableException
      * @return ResponseEntity<ErrorResponse>
      */
     @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -121,7 +118,6 @@ public class GlobalExceptionHandler {
 
     /**
      * API 호출 시 'Parameter' 내에 데이터 값이 존재하지 않은 경우
-     * @param e MissingServletRequestParameterException
      * @return ResponseEntity<ErrorResponse>
      */
     @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -133,7 +129,6 @@ public class GlobalExceptionHandler {
 
     /**
      * 잘못된 URL 호출 시
-     * @param e NoHandlerFoundException
      * @return ResponseEntity<ErrorResponse>
      */
     @ResponseStatus(HttpStatus.NOT_FOUND)
@@ -145,7 +140,6 @@ public class GlobalExceptionHandler {
 
     /**
      * API 호출 시 데이터를 반환할 수 없는 경우
-     * @param e HttpMessageNotWritableException
      * @return ResponseEntity<ErrorResponse>
      */
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -155,9 +149,9 @@ public class GlobalExceptionHandler {
         return ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
     }
 
+
     /**
      * NullPointerException이 발생한 경우
-     * @param e NullPointerException
      * @return ResponseEntity<ErrorResponse>
      */
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/kcy/fitapet/global/common/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/filter/JwtExceptionFilter.java
@@ -35,7 +35,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(e.getErrorCode().getHttpStatus().value());
 
-        AuthErrorResponse errorResponse = new AuthErrorResponse(e.getErrorCode().name(), e.getErrorCode().getMessage());
+        AuthErrorResponse errorResponse = new AuthErrorResponse("error", e.getErrorCode().getMessage());
         objectMapper.writeValue(response.getWriter(), errorResponse);
     }
 }

--- a/src/main/java/com/kcy/fitapet/global/common/security/oauth2/OAuth2Provider.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/oauth2/OAuth2Provider.java
@@ -1,4 +1,5 @@
 package com.kcy.fitapet.global.common.security.oauth2;
 
 public interface OAuth2Provider {
+
 }

--- a/src/main/java/com/kcy/fitapet/global/common/util/jwt/exception/AuthErrorResponse.java
+++ b/src/main/java/com/kcy/fitapet/global/common/util/jwt/exception/AuthErrorResponse.java
@@ -2,6 +2,6 @@ package com.kcy.fitapet.global.common.util.jwt.exception;
 
 public record AuthErrorResponse(String code, String message) {
     @Override public String toString() {
-        return String.format("AuthErrorResponse(code=%s, message=%s)", code, message);
+        return "AuthErrorResponse(code=" + code + ", message=" + message + ")";
     }
 }

--- a/src/main/java/com/kcy/fitapet/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/kcy/fitapet/global/config/security/SecurityConfig.java
@@ -29,20 +29,10 @@ import java.util.Arrays;
 public class SecurityConfig {
     private final JwtSecurityConfig jwtSecurityConfig;
 
-    private final String[] publicEndpoints = {
-            "/api/v1/test", "/api/v1/test/**",
+    private static final String[] publicReadOnlyPublicEndpoints = {
             "/favicon.ico",
-
             // Swagger
             "/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",
-
-            // API
-            "/api/v1/auth/register", "/api/v1/auth/login", "/api/v1/auth/refresh",
-            "/api/v1/auth/register-sms/**", "/api/v1/auth/search-sms/**",
-            "/api/v1/accounts/search", "/api/v1/accounts/search/**",
-    };
-    private static final String[] publicReadOnlyPublicEndpoints = {
-            "/api/v1/accounts/exists", "/api/v1/accounts/exists/**"
     };
 
     @Bean
@@ -72,9 +62,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         auth -> auth.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                                         .requestMatchers(HttpMethod.OPTIONS, "*").permitAll()
-                                        .requestMatchers(publicEndpoints).permitAll()
                                         .requestMatchers(HttpMethod.GET, publicReadOnlyPublicEndpoints).permitAll()
-                                        .anyRequest().authenticated()
+                                        .anyRequest().permitAll()
                 )
                 .exceptionHandling(
                         exception -> exception

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,12 @@ spring:
     host: ${REDIS_HOST}
     port: ${REDIS_PORT}
 
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
+
 #  security:
 #    oauth2:
 #      client:
@@ -138,6 +144,7 @@ spring:
     generate-ddl: false
     hibernate:
       ddl-auto: none
+    show-sql: false
 
   main:
     allow-bean-definition-overriding: true
@@ -145,6 +152,12 @@ spring:
   data.redis:
     host: ${REDIS_HOST}
     port: ${REDIS_PORT}
+
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8


### PR DESCRIPTION
## 작업 이유
- 기존 url 경로가 REST 원칙을 준수하지 못함
- Web Security 방식으로 인한 문자열과 Controller 구조 종속성 이슈

## 작업 사항
> ⚠️ 아직 배포 서버에 반영되지 않아서, Postman을 수정하지 않은 상태입니다.
- jwt 생성을 위해 단말 정보 추가 입력(보류 -> 런칭 직전/혹은 후에 리팩토링)
- api url REST 규격에 맞게 재정의
  1. AccountApi
      • `GET /api/v1/accounts` -> `GET /api/v1/accounts/{id}`
      • `PUT /api/v1/accounts` -> `PUT /api/v1/accounts/{id}`
      • `GET /api/v1/accounts/notify` -> `GET /api/v1/accounts/{id}/notify`
- id와 access token을 전달한 유저가 일치하지 않을 시, 권한 에러
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/d3c8906c-d7f8-4388-9687-3e58cb2a6029)

- 기존에 존재하지 않는 자원 요청 시 권한 에러 → 404 에러로 변경
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/9d245efe-762b-494c-b6e1-20a06a73b3f4)

## 이슈 연결
close #45 
