### PR TITLE
✨ 무중단 배포 서버 구축

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,42 @@
 version: '3.7'
 services:
-  proxy:
-    image: nginx:latest
+  certbot:
+    container_name: certbot
+    image: certbot/certbot
+    restart: unless-stopped
+    volumes:
+      - /letsencrypt/certbot/conf:/etc/letsencrypt
+      - /letsencrypt/certbot/www:/var/www/certbot
+    depends_on:
+      - nginx
+    networks:
+      - was-net
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+
+  nginx:
+    image: nginx:1.15-alpine
     container_name: nginx-proxy
     restart: always
+    volumes:
+      - ./proxy/conf.d/default.conf:/etc/nginx/conf.d/default.conf
+      - /letsencrypt/certbot/conf:/etc/letsencrypt
+      - /letsencrypt/certbot/www:/var/www/certbot
+      - /var/log/nginx:/var/log/nginx/
     ports:
-      - "8083:80"
+      - "80:80"
       - "443:443"
     networks:
       - was-net
     depends_on:
       - server
+    command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''
 
   server:
     image: jaeseo/fitapet:latest
     container_name: fitapet-api
     restart: unless-stopped
     expose:
-      - "8080:8080"
+      - "8080"
     env_file:
       - .env
     environment:
@@ -27,5 +46,4 @@ services:
 
 networks:
   was-net:
-    name: was-net
     external: true

--- a/proxy/conf.d/default.conf
+++ b/proxy/conf.d/default.conf
@@ -1,32 +1,51 @@
+upstream docker-server {
+    server server:8080;
+}
+
 server {
-    listen 80;  # 서버가 리스닝할 포트를 설정하는 지시자 (server 블록 하나 당 하나의 웹 사이트 선언)
-    listen [::]:80;
+    listen 80;
 
-#     server_name localhost;  # 서버의 도메인 이름을 설정하는 지시자 (request header의 host와 비교하여 일치하는 경우에만 처리)
+    server_name fitapet.co.kr;
 
-    access_log /var/log/nginx/access.log;  # access_log 지시자는 접속 로그를 기록할 파일의 경로를 설정
+    access_log /var/log/nginx/access.log;
+
+        location /.well-known/acme-challenge/ {
+                allow all;
+                root /var/www/certbot;
+        }
 
     location / {
-        root /usr/share/nginx/html; # root 지시자는 요청이 들어왔을 때, 해당 요청을 처리할 파일의 기본 경로를 설정
-        index index.html index.htm; # index 지시자는 root 지시자에서 설정한 경로에서 찾을 파일의 이름을 설정
-        try_files $uri $uri/ /index.html =404;  # try_files 지시자는 파일을 찾을 수 없는 경우의 처리 방법을 설정
+                return 301 https://$host$request_uri;
     }
+}
 
-    location /api {
-        proxy_pass http://docker-server; # proxy_pass 지시자는 요청을 전달할 서버의 주소를 설정
-        proxy_redirect off; # proxy_redirect 지시자는 리다이렉션을 설정
-        proxy_set_header Host $host:$server_port; # proxy_set_header 지시자는 요청 헤더의 값을 변경
+server {
+        listen 443 ssl;
+
+        server_name fitapet.co.kr;
+
+        ssl_certificate /etc/letsencrypt/live/fitapet.co.kr/fullchain.pem;
+        ssl_certificate_key     /etc/letsencrypt/live/fitapet.co.kr/privkey.pem;
+        include /etc/letsencrypt/options-ssl-nginx.conf;
+        ssl_dhparam     /etc/letsencrypt/ssl-dhparams.pem;
+
+    access_log /var/log/nginx/access.log;
+
+        location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html =404;
+        }
+
+        location /api {
+                proxy_pass      http://docker-server;
+                proxy_http_version 1.1;
+
+                proxy_redirect off;
+        proxy_set_header Host $host:$server_port;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-Host $server_name; # proxy_set_header 지시자는 요청 헤더의 값을 변경
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; # proxy_set_header 지시자는 요청 헤더의 값을 변경
-        proxy_set_header X-Forwarded-Proto $scheme; # proxy_set_header 지시자는 요청 헤더의 값을 변경
-    }
-
-#     location /socket {
-#         proxy_pass http://docker-server;
-#         proxy_http_version 1.1; # proxy_http_version 지시자는 HTTP 버전을 설정
-#         proxy_set_header Upgrade $http_upgrade; # proxy_set_header 지시자는 요청 헤더의 값을 변경
-#         proxy_set_header Connection "upgrade"; # proxy_set_header 지시자는 요청 헤더의 값을 변경
-#         proxy_set_header Host $host; # proxy_set_header 지시자는 요청 헤더의 값을 변경
-#     }
+        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        }
 }

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+docker-compose down
+
+docker image rm -f $(docker image ls -f reference='jaeseo/*' -q)
+docker container rm fitapet-api
+
+docker-compose up -d


### PR DESCRIPTION
## 작업 이유
- http → https 전환
- Docker를 활용한 무중단 배포 서버 구축
- Ngnix reverse proxy server 구축

## 작업 사항
> 💡 지금까지의 모든 `fitapet.co.kr:8080` uri를 `https://fitapet.co.kr`로 바꾸시면 됩니다.

> ⚠️ Swagger 문서가 보이지 않는 이슈 발생. proxy 재조정 단계 필요
- letsencrypt, cerbot으로 domain 인증서 발급
- 서버 환경에 맞게 defalut.conf 재정의
- proxy log 관리 및 인증 검사 적용
- http 요청 시, https로 redirect
- shell script와 docker-compose로 명령어 자동화

## 이슈 연결
close #25 