### PR TITLE
✨ Care 유효성 검사와 등록 API

### DIFF
--- a/src/main/java/com/kcy/fitapet/domain/care/api/CareApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/api/CareApi.java
@@ -1,6 +1,6 @@
 package com.kcy.fitapet.domain.care.api;
 
-import com.kcy.fitapet.domain.care.dto.CareSaveDto;
+import com.kcy.fitapet.domain.care.dto.CareSaveReq;
 import com.kcy.fitapet.domain.care.service.component.CareManageService;
 import com.kcy.fitapet.global.common.response.SuccessResponse;
 import com.kcy.fitapet.global.common.security.authentication.CustomUserDetails;
@@ -31,7 +31,7 @@ public class CareApi {
     @PreAuthorize("isAuthenticated() && @managerAuthorize.isManager(principal.userId, #petId)")
     public ResponseEntity<?> saveCare(
             @PathVariable("pet_id") Long petId,
-            @RequestBody @Valid CareSaveDto.Request request,
+            @RequestBody @Valid CareSaveReq.Request request,
             @AuthenticationPrincipal CustomUserDetails user
             ) {
         careManageService.saveCare(user.getUserId(), petId, request);

--- a/src/main/java/com/kcy/fitapet/domain/care/dto/CareCategoryDto.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/dto/CareCategoryDto.java
@@ -1,6 +1,9 @@
 package com.kcy.fitapet.domain.care.dto;
 
 import com.kcy.fitapet.domain.care.domain.CareCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.util.ArrayList;
@@ -8,6 +11,7 @@ import java.util.List;
 
 public class CareCategoryDto {
     private List<CareCategorySummary> careCategorySummaries = new ArrayList<>();
+    private List<CareCategoryExist> careCategoryExists = new ArrayList<>();
 
     public static CareCategoryDto from(List<CareCategory> careCategories) {
         CareCategoryDto careCategoryDto = new CareCategoryDto();
@@ -15,12 +19,19 @@ public class CareCategoryDto {
         return careCategoryDto;
     }
 
-    public List<CareCategorySummary> getCareCategorySummaries() {
-        List<CareCategorySummary> view = new ArrayList<>(careCategorySummaries);
-        return view;
+    public void addCareCategoryExist(Long petId, Long careCategoryId) {
+        careCategoryExists.add(new CareCategoryExist(petId, careCategoryId));
     }
 
-    public void addCareCategorySummary(CareCategory careCategory) {
+    public List<CareCategorySummary> getCareCategorySummaries() {
+        return List.copyOf(careCategorySummaries);
+    }
+
+    public List<CareCategoryExist> getCareCategoryExists() {
+        return List.copyOf(careCategoryExists);
+    }
+
+    private void addCareCategorySummary(CareCategory careCategory) {
         careCategorySummaries.add(CareCategorySummary.from(careCategory));
     }
 
@@ -34,5 +45,19 @@ public class CareCategoryDto {
                     careCategory.getCategoryName()
             );
         }
+    }
+
+    @Schema(description = "반려동물 케어 카테고리 존재 여부 확인 요청")
+    public record CareCategoryExistRequest(
+            @NotEmpty @Schema(description = "카테고리 이름", example = "식사")
+            String categoryName,
+            @NotNull @Schema(description = "반려동물 ID 목록", example = "[1, 2]")
+            List<Long> pets) { }
+
+    private record CareCategoryExist(
+            Long petId,
+            Long careCategoryId
+    ) {
+
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/care/service/component/CareManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/service/component/CareManageService.java
@@ -4,11 +4,12 @@ import com.kcy.fitapet.domain.care.domain.Care;
 import com.kcy.fitapet.domain.care.domain.CareCategory;
 import com.kcy.fitapet.domain.care.domain.CareDate;
 import com.kcy.fitapet.domain.care.dto.CareCategoryDto;
-import com.kcy.fitapet.domain.care.dto.CareSaveDto;
+import com.kcy.fitapet.domain.care.dto.CareSaveReq;
 import com.kcy.fitapet.domain.care.service.module.CareSaveService;
 import com.kcy.fitapet.domain.care.service.module.CareSearchService;
 import com.kcy.fitapet.domain.member.service.module.MemberSearchService;
 import com.kcy.fitapet.domain.pet.domain.Pet;
+import com.kcy.fitapet.domain.pet.exception.PetErrorCode;
 import com.kcy.fitapet.domain.pet.service.module.PetSearchService;
 import com.kcy.fitapet.global.common.response.exception.GlobalErrorException;
 import com.kcy.fitapet.global.common.security.jwt.exception.AuthErrorCode;
@@ -37,29 +38,45 @@ public class CareManageService {
     }
 
     @Transactional
-    public void saveCare(Long userId, Long petId, CareSaveDto.Request request) {
-        CareSaveDto.CategoryDto categoryDto = request.category();
-        CareSaveDto.CareInfoDto careInfoDto = request.care();
-        List<Long> petIds = request.pets();
+    public void saveCare(Long userId, Long petId, CareSaveReq.Request request) {
+        CareSaveReq.CategoryDto categoryDto = request.category();
+        CareSaveReq.CareInfoDto careInfoDto = request.care();
+        List<CareSaveReq.AdditionalPetDto> additionalPetDtos = request.pets();
 
-        if (!petIds.contains(petId)) petIds.add(petId);
+        List<Long> petIds = additionalPetDtos.stream().map(CareSaveReq.AdditionalPetDto::petId).toList();
+        log.info("추가 케어 등록 요청 - 반려 동물 ID: {}, 카테고리 이름: {}", petIds, categoryDto.categoryName());
+        if (!memberSearchService.isManagerAll(userId, petIds)) {
+            log.warn("관리자 자격이 없는 반려 동물에 대한 케어 등록 요청");
+            throw new GlobalErrorException(PetErrorCode.NOT_MANAGER_PET);
+        }
 
-        List<Pet> pets = petSearchService.findPetsByIds(petIds);
+        if (!petIds.contains(petId))
+            additionalPetDtos.add(CareSaveReq.AdditionalPetDto.of(petId, categoryDto.categoryId()));
+        petSearchService.findPetsByIds(petIds);
 
-        if (!memberSearchService.isManagerAll(userId, petIds))
-            throw new GlobalErrorException(AuthErrorCode.FORBIDDEN_ACCESS_TOKEN);
-
-        persistAboutCare(categoryDto, careInfoDto, pets);
+        persistAboutCare(categoryDto, careInfoDto, additionalPetDtos);
     }
 
-    private void persistAboutCare(CareSaveDto.CategoryDto categoryDto, CareSaveDto.CareInfoDto careInfoDto, List<Pet> pets) {
-        List<CareCategory> categories = new ArrayList<>();
-        for (Pet pet : pets) {
-            CareCategory category = mappingCareCategory(categoryDto, pet);
+    private void persistAboutCare(
+            CareSaveReq.CategoryDto categoryDto,
+            CareSaveReq.CareInfoDto careInfoDto,
+            List<CareSaveReq.AdditionalPetDto> additionalPetDtos
+    ) {
+        List<CareCategory> categories = new ArrayList<>(careSearchService.findAllCareCategoriesById(
+                additionalPetDtos.stream().map(CareSaveReq.AdditionalPetDto::categoryId).filter(id -> !id.equals(0L)).toList()));
+
+        for (CareSaveReq.AdditionalPetDto dto : additionalPetDtos) {
+            if (dto.categoryId() != 0L) continue;
+
+            Pet pet = petSearchService.findPetById(dto.petId());
+            log.info("새로운 케어 카테고리 등록 - 반려 동물 ID: {}, 카테고리 이름: {}", pet.getId(), categoryDto.categoryName());
+            CareCategory category = categoryDto.toCareCategory();
+            category.updatePet(pet);
             categories.add(category);
         }
         careSaveService.saveCareCategories(categories);
 
+        log.info("등록된 카테고리 목록: {}", categories);
         List<Care> cares = new ArrayList<>();
         for (CareCategory category : categories) {
             Care care = careInfoDto.toCare(category);
@@ -75,13 +92,5 @@ public class CareManageService {
             dates.addAll(requestDates);
         }
         careSaveService.saveCareDates(dates);
-    }
-
-    private CareCategory mappingCareCategory(CareSaveDto.CategoryDto categoryDto, Pet pet) {
-        CareCategory category = (categoryDto.state().equals(CareSaveDto.CategoryState.EXIST))
-                ? careSearchService.findCareCategoryById(categoryDto.categoryId())
-                : categoryDto.toCareCategory();
-        category.updatePet(pet);
-        return category;
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/care/service/module/CareSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/service/module/CareSearchService.java
@@ -4,6 +4,7 @@ import com.kcy.fitapet.domain.care.dao.CareCategoryRepository;
 import com.kcy.fitapet.domain.care.dao.CareDateRepository;
 import com.kcy.fitapet.domain.care.dao.CareRepository;
 import com.kcy.fitapet.domain.care.domain.CareCategory;
+import com.kcy.fitapet.domain.care.dto.CareCategoryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +24,29 @@ public class CareSearchService {
     }
 
     @Transactional(readOnly = true)
+    public List<CareCategory> findAllCareCategoriesById(List<Long> categoryIds) {
+        return careCategoryRepository.findAllById(categoryIds);
+    }
+
+    @Transactional(readOnly = true)
     public List<CareCategory> findAllCareCategoriesByPetId(Long petId) {
         return careCategoryRepository.findAllByPet_Id(petId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<?> checkCategoryExist(String categoryName, List<Long> petIds) {
+        CareCategoryDto dto = new CareCategoryDto();
+
+        for (Long petId : petIds) {
+            List<CareCategory> careCategories = careCategoryRepository.findAllByPet_Id(petId);
+            for (CareCategory careCategory : careCategories) {
+                if (careCategory.getCategoryName().equals(categoryName)) {
+                    dto.addCareCategoryExist(petId, careCategory.getId());
+                    break;
+                }
+            }
+        }
+
+        return dto.getCareCategoryExists();
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/member/service/component/MemberAuthService.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/service/component/MemberAuthService.java
@@ -7,7 +7,6 @@ import com.kcy.fitapet.domain.member.exception.AccountErrorCode;
 import com.kcy.fitapet.domain.member.exception.SmsErrorCode;
 import com.kcy.fitapet.domain.member.service.module.MemberSaveService;
 import com.kcy.fitapet.domain.member.service.module.MemberSearchService;
-import com.kcy.fitapet.domain.oauth.service.module.OauthSearchService;
 import com.kcy.fitapet.global.common.redis.forbidden.ForbiddenTokenService;
 import com.kcy.fitapet.global.common.redis.refresh.RefreshToken;
 import com.kcy.fitapet.global.common.redis.refresh.RefreshTokenService;
@@ -28,6 +27,7 @@ import com.kcy.fitapet.global.common.util.sms.dto.SmsReq;
 import com.kcy.fitapet.global.common.util.sms.dto.SmsRes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -80,12 +80,12 @@ public class MemberAuthService {
     }
 
     @Transactional
-    public Jwt login(SignInReq dto) {
+    public Pair<Long, Jwt> login(SignInReq dto) {
         Member member = memberSearchService.findByUid(dto.uid());
         if (!member.checkPassword(dto.password(), bCryptPasswordEncoder))
             throw new GlobalErrorException(AccountErrorCode.NOT_MATCH_PASSWORD_ERROR);
 
-        return generateToken(JwtUserInfo.from(member));
+        return Pair.of(member.getId(), generateToken(JwtUserInfo.from(member)));
     }
 
     @Transactional

--- a/src/main/java/com/kcy/fitapet/domain/member/service/module/MemberSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/service/module/MemberSearchService.java
@@ -71,7 +71,7 @@ public class MemberSearchService {
     @Transactional(readOnly = true)
     public boolean isManagerAll(Long memberId, List<Long> petIds) {
         if (petIds.isEmpty()) {
-            return false;
+            return true;
         }
 
         for (Long petId : petIds) {

--- a/src/main/java/com/kcy/fitapet/domain/pet/api/PetApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/api/PetApi.java
@@ -1,5 +1,6 @@
 package com.kcy.fitapet.domain.pet.api;
 
+import com.kcy.fitapet.domain.care.dto.CareCategoryDto;
 import com.kcy.fitapet.domain.pet.dto.PetRegisterReq;
 import com.kcy.fitapet.domain.pet.service.component.PetManageService;
 import com.kcy.fitapet.global.common.response.ErrorResponse;
@@ -8,6 +9,7 @@ import com.kcy.fitapet.global.common.response.SuccessResponse;
 import com.kcy.fitapet.global.common.security.authentication.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -55,5 +57,13 @@ public class PetApi {
         return ResponseEntity.ok(SuccessResponse.from("pets", pets));
     }
 
+    @Operation(summary = "반려동물 케어 카테고리 유효성 검사")
+    @Parameter(name = "user_id", description = "조회할 유저 ID", in = ParameterIn.PATH, required = true)
+    @PostMapping("/categories-check")
+    @PreAuthorize("isAuthenticated() and #userId == principal.userId")
+    public ResponseEntity<?> checkCategoryExist(@PathVariable("user_id") Long userId, @RequestBody @Valid CareCategoryDto.CareCategoryExistRequest request) {
+        List<?> result = petManageService.checkCategoryExist(userId, request.categoryName(), request.pets());
+        return ResponseEntity.ok(SuccessResponse.from("categories", result));
+    }
 
 }

--- a/src/main/java/com/kcy/fitapet/domain/pet/exception/PetErrorCode.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/exception/PetErrorCode.java
@@ -1,0 +1,20 @@
+package com.kcy.fitapet.domain.pet.exception;
+
+import com.kcy.fitapet.global.common.response.code.StatusCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PetErrorCode implements StatusCode {
+    NOT_MANAGER_PET(HttpStatus.FORBIDDEN, "관리자 자격이 없는 반려 동물에 대한 요청");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/src/main/java/com/kcy/fitapet/domain/pet/service/component/PetManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/service/component/PetManageService.java
@@ -1,5 +1,6 @@
 package com.kcy.fitapet.domain.pet.service.component;
 
+import com.kcy.fitapet.domain.care.service.module.CareSearchService;
 import com.kcy.fitapet.domain.member.domain.Manager;
 import com.kcy.fitapet.domain.member.domain.Member;
 import com.kcy.fitapet.domain.member.service.module.MemberSaveService;
@@ -8,6 +9,9 @@ import com.kcy.fitapet.domain.member.type.ManageType;
 import com.kcy.fitapet.domain.pet.domain.Pet;
 import com.kcy.fitapet.domain.pet.dto.PetInfoRes;
 import com.kcy.fitapet.domain.pet.service.module.PetSaveService;
+import com.kcy.fitapet.domain.pet.service.module.PetSearchService;
+import com.kcy.fitapet.global.common.response.exception.GlobalErrorException;
+import com.kcy.fitapet.global.common.security.jwt.exception.AuthErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +24,8 @@ public class PetManageService {
     private final MemberSearchService memberSearchService;
     private final MemberSaveService memberSaveService;
     private final PetSaveService petSaveService;
+    private final PetSearchService petSearchService;
+    private final CareSearchService careSearchService;
 
     @Transactional
     public void savePet(Pet pet, Long memberId) {
@@ -33,5 +39,13 @@ public class PetManageService {
     public PetInfoRes findPetsSummaryByUserId(Long userId) {
         List<Pet> pets = memberSearchService.findAllManagerByMemberId(userId).stream().map(Manager::getPet).toList();
         return PetInfoRes.ofSummary(pets);
+    }
+
+    @Transactional(readOnly = true)
+    public List<?> checkCategoryExist(Long userId, String categoryName, List<Long> petIds) {
+        if (!memberSearchService.isManagerAll(userId, petIds))
+            throw new GlobalErrorException(AuthErrorCode.FORBIDDEN_ACCESS_TOKEN);
+
+        return careSearchService.checkCategoryExist(categoryName, petIds);
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/pet/service/module/PetSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/service/module/PetSearchService.java
@@ -1,5 +1,8 @@
 package com.kcy.fitapet.domain.pet.service.module;
 
+import com.kcy.fitapet.domain.care.dao.CareCategoryRepository;
+import com.kcy.fitapet.domain.care.domain.CareCategory;
+import com.kcy.fitapet.domain.care.dto.CareCategoryDto;
 import com.kcy.fitapet.domain.pet.dao.PetRepository;
 import com.kcy.fitapet.domain.pet.domain.Pet;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PetSearchService {
     private final PetRepository petRepository;
+    private final CareCategoryRepository careCategoryRepository;
 
     @Transactional(readOnly = true)
     public Pet findPetById(Long id) {


### PR DESCRIPTION
## 작업 이유
> 💡 아직 서버 반영 안 했습니다. 올리면 따로 연락드리겠습니다.
- 하는 김에 로그인 시 pk값 반환
- Pet pk 리스트 기반 카테고리명 존재 유무 API
- Care 등록 API 개편

## 작업 사항
### 1️⃣ 로그인 시, 사용자 PK 반환
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/a68df3ae-b1c1-4630-ab9c-791fb669ece7)

### 2️⃣ Pet pk 리스트 기반 카테고리명 존재 유무 API
- 요청 `POST /api/v2/users/{user_id}/pets/categories-check`
- 기본적으로 배열을 반환합니다.
- 만약 반려동물 중 "categoryName"에 대한 cateogry가 이미 존재하는 경우, `Pet pk`와 `category pk`를 반환합니다.
- 사용자가 기존 카테고리에 함께 등록하길 원할 경우, 제공한 2개의 pk값을 필요로 합니다.

**🟡 "careName"에 대한 category가 존재하지 않는 경우**
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/0ce65820-b0a3-4f90-b30e-ead416c0a524)

<br/>

**🟡 "careName"에 대한 category가 하나라도 존재하는 경우**
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/c2cd8c87-b27e-4f97-8a63-42e393b5c03d)
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/6cabf193-6ccd-4ccb-8af2-1f058a3d5a26)

### 3️⃣ Care 등록 API 개편
> ⚠️ 더 이상 `state` 필드를 사용하지 않습니다!
- 요청 `POST /api/v2/pets/{pet_id}/cares`
- 성공하면 응답은 언제나 `data: null`을 반환합니다.
- 신규 생성은 state가 아닌, categoryId값으로 판단합니다.
   - categoryId가 0이면 신규, 아니면 기존 카테고리 record에 매핑
- 함께 등록할 시엔 `(2)`의 API로 얻은 기존 categoryId를 보내주셔야 합니다.
   - 만약 해당 categoryName으로 등록된 categoryId가 없으면, 마찬가지로 0을 넣어주시면 됩니다.
   - 현재 케어를 등록하려는 반려동물 정보가 pets 배열에 포함이 되든, 안 되든 무관합니다.

**🟡 신규 카테고리에 케어를 등록하는 경우**
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/728937fe-79c9-488b-9751-6c8cdade8dc7)

<br/>

**🟡 일부는 기존 카테고리, 일부는 신규 카테고리에 케어를 등록하는 경우**
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/d130fd8c-1fd4-497c-a290-41622fec0e6e)

## 이슈 연결
close #67 #68 #69