### PR TITLE
🐛 OIDC oauth_id Long 타입 범위 제한 이슈 해결

### DIFF
--- a/src/main/java/com/kcy/fitapet/domain/oauth/api/OauthApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/oauth/api/OauthApi.java
@@ -13,6 +13,7 @@ import com.kcy.fitapet.global.common.util.sms.dto.SmsRes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -42,10 +43,7 @@ public class OauthApi {
     private final CookieUtil cookieUtil;
 
     @Operation(summary = "OAuth 로그인")
-    @Parameters({
-            @Parameter(name = "provider", description = "OAuth 제공자"),
-            @Parameter(name = "req", description = "OAuth 로그인 요청 정보")
-    })
+    @Parameter(name = "provider", description = "OAuth 제공자", required = true, in = ParameterIn.QUERY)
     @PostMapping("")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> signIn(
@@ -66,15 +64,14 @@ public class OauthApi {
 
     @Operation(summary = "OAuth 회원가입", description = "/{id}/sms로 전화번호 인증 후, accessToken 발급이 선행되어야 한다.")
     @Parameters({
-            @Parameter(name = "id", description = "OAuth 제공자에서 발급받은 ID"),
-            @Parameter(name = "provider", description = "OAuth 제공자"),
-            @Parameter(name = "accessToken", description = "OAuth 전화번호 인증 시 발급받은 accessToken"),
-            @Parameter(name = "req", description = "OAuth 회원가입 요청 정보")
+            @Parameter(name = "id", description = "OAuth 제공자에서 발급받은 ID", required = true, in = ParameterIn.PATH),
+            @Parameter(name = "provider", description = "OAuth 제공자", required = true, in = ParameterIn.QUERY),
+            @Parameter(name = "accessToken", description = "OAuth 전화번호 인증 시 발급받은 accessToken", required = true, in = ParameterIn.HEADER),
     })
     @PostMapping("/{id}")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> signUp(
-            @PathVariable("id") BigInteger id,
+            @PathVariable("id") String id,
             @RequestParam("provider") ProviderType provider,
             @RequestHeader("Authorization") String accessToken,
             @RequestBody @Valid OauthSignUpReq req
@@ -91,14 +88,14 @@ public class OauthApi {
 
     @Operation(summary = "OAuth 회원가입 전화번호 인증")
     @Parameters({
-            @Parameter(name = "id", description = "OAuth 제공자에서 발급받은 ID"),
-            @Parameter(name = "provider", description = "OAuth 제공자"),
-            @Parameter(name = "req", description = "OAuth 회원가입 전화번호 인증 요청 정보")
+            @Parameter(name = "id", description = "OAuth 제공자에서 발급받은 ID", required = true, in = ParameterIn.PATH),
+            @Parameter(name = "provider", description = "OAuth 제공자", required = true, in = ParameterIn.QUERY),
+            @Parameter(name = "code", description = "인증번호", in = ParameterIn.QUERY),
     })
     @PostMapping("/{id}/sms")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> signUpSmsAuthorization(
-        @PathVariable("id") BigInteger id,
+        @PathVariable("id") String id,
         @RequestParam("provider") ProviderType provider,
         @RequestParam(value = "code", required = false) String code,
         @RequestBody @Valid OauthSmsReq req

--- a/src/main/java/com/kcy/fitapet/domain/oauth/api/OauthApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/oauth/api/OauthApi.java
@@ -24,6 +24,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigInteger;
 import java.util.Map;
 import java.util.Optional;
 
@@ -73,7 +74,7 @@ public class OauthApi {
     @PostMapping("/{id}")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> signUp(
-            @PathVariable("id") Long id,
+            @PathVariable("id") BigInteger id,
             @RequestParam("provider") ProviderType provider,
             @RequestHeader("Authorization") String accessToken,
             @RequestBody @Valid OauthSignUpReq req
@@ -97,7 +98,7 @@ public class OauthApi {
     @PostMapping("/{id}/sms")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> signUpSmsAuthorization(
-        @PathVariable("id") Long id,
+        @PathVariable("id") BigInteger id,
         @RequestParam("provider") ProviderType provider,
         @RequestParam(value = "code", required = false) String code,
         @RequestBody @Valid OauthSmsReq req

--- a/src/main/java/com/kcy/fitapet/domain/oauth/dao/OauthRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/oauth/dao/OauthRepository.java
@@ -4,10 +4,11 @@ import com.kcy.fitapet.domain.oauth.domain.OauthAccount;
 import com.kcy.fitapet.domain.oauth.type.ProviderType;
 import com.kcy.fitapet.global.common.repository.ExtendedRepository;
 
+import java.math.BigInteger;
 import java.util.Optional;
 
 public interface OauthRepository extends ExtendedRepository<OauthAccount, Long> {
-    Optional<OauthAccount> findByOauthIdAndProvider(Long oauthId, ProviderType provider);
-    boolean existsByOauthIdAndProvider(Long oauthId, ProviderType provider);
+    Optional<OauthAccount> findByOauthIdAndProvider(BigInteger oauthId, ProviderType provider);
+    boolean existsByOauthIdAndProvider(BigInteger oauthId, ProviderType provider);
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/kcy/fitapet/domain/oauth/domain/OauthAccount.java
+++ b/src/main/java/com/kcy/fitapet/domain/oauth/domain/OauthAccount.java
@@ -7,6 +7,8 @@ import com.kcy.fitapet.domain.oauth.type.converter.ProviderTypeConverter;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigInteger;
+
 @Entity
 @Getter
 @Table(name = "OAUTH")
@@ -17,7 +19,7 @@ public class OauthAccount extends DateAuditable {
     private Long id;
 
     @Column(name = "oauth_id")
-    private Long oauthId;
+    private BigInteger oauthId;
     @Convert(converter = ProviderTypeConverter.class)
     private ProviderType provider;
     private String email;
@@ -27,14 +29,14 @@ public class OauthAccount extends DateAuditable {
     private Member member;
 
     @Builder
-    public OauthAccount(Long id, Long oauthId, ProviderType provider, String email) {
+    public OauthAccount(Long id, BigInteger oauthId, ProviderType provider, String email) {
         this.id = id;
         this.oauthId = oauthId;
         this.provider = provider;
         this.email = email;
     }
 
-    public static OauthAccount of(Long oauthId, ProviderType provider, String email) {
+    public static OauthAccount of(BigInteger oauthId, ProviderType provider, String email) {
         return OauthAccount.builder()
                 .oauthId(oauthId)
                 .provider(provider)

--- a/src/main/java/com/kcy/fitapet/domain/oauth/dto/OauthSignInReq.java
+++ b/src/main/java/com/kcy/fitapet/domain/oauth/dto/OauthSignInReq.java
@@ -4,11 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
+import java.math.BigInteger;
+
 @Schema(description = "Oauth Sign In Request")
 public record OauthSignInReq(
         @Schema(description = "Member Oauth Id")
         @NotNull
-        Long id,
+        BigInteger id,
         @Schema(description = "Member Oauth Id Token")
         @NotEmpty
         String idToken,

--- a/src/main/java/com/kcy/fitapet/domain/oauth/dto/OauthSignInReq.java
+++ b/src/main/java/com/kcy/fitapet/domain/oauth/dto/OauthSignInReq.java
@@ -9,8 +9,8 @@ import java.math.BigInteger;
 @Schema(description = "Oauth Sign In Request")
 public record OauthSignInReq(
         @Schema(description = "Member Oauth Id")
-        @NotNull
-        BigInteger id,
+        @NotEmpty
+        String id,
         @Schema(description = "Member Oauth Id Token")
         @NotEmpty
         String idToken,

--- a/src/main/java/com/kcy/fitapet/domain/oauth/service/module/OauthSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/oauth/service/module/OauthSearchService.java
@@ -10,13 +10,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigInteger;
+
 @Service
 @RequiredArgsConstructor
 public class OauthSearchService {
     private final OauthRepository oauthRepository;
 
     @Transactional(readOnly = true)
-    public boolean isExistMember(Long oauthId, ProviderType provider) {
+    public boolean isExistMember(BigInteger oauthId, ProviderType provider) {
         return oauthRepository.existsByOauthIdAndProvider(oauthId, provider);
     }
 
@@ -26,7 +28,7 @@ public class OauthSearchService {
     }
 
     @Transactional(readOnly = true)
-    public Member findMemberByOauthIdAndProvider(Long oauthId, ProviderType provider) {
+    public Member findMemberByOauthIdAndProvider(BigInteger oauthId, ProviderType provider) {
         OauthAccount oauthAccount = oauthRepository.findByOauthIdAndProvider(oauthId, provider)
                 .orElseThrow(() -> new GlobalErrorException(OauthException.NOT_FOUND_MEMBER));
         return oauthAccount.getMember();

--- a/src/main/java/com/kcy/fitapet/global/common/redis/oauth/OIDCToken.java
+++ b/src/main/java/com/kcy/fitapet/global/common/redis/oauth/OIDCToken.java
@@ -23,7 +23,7 @@ public class OIDCToken {
         this.ttl = ttl;
     }
 
-    public static OIDCToken of(String token, ProviderType provider, BigInteger id, long ttl) {
+    public static OIDCToken of(String token, ProviderType provider, String id, long ttl) {
         return OIDCToken.builder()
                 .token(token)
                 .providerWithId(provider.name() + "@" + id)
@@ -39,7 +39,7 @@ public class OIDCToken {
         return providerWithId.split("@")[0];
     }
 
-    public Long getId() {
-        return Long.parseLong(providerWithId.split("@")[1]);
+    public String getId() {
+        return providerWithId.split("@")[1];
     }
 }

--- a/src/main/java/com/kcy/fitapet/global/common/redis/oauth/OIDCToken.java
+++ b/src/main/java/com/kcy/fitapet/global/common/redis/oauth/OIDCToken.java
@@ -6,6 +6,8 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
+import java.math.BigInteger;
+
 @RedisHash("oidcToken")
 public class OIDCToken {
     @Id
@@ -21,7 +23,7 @@ public class OIDCToken {
         this.ttl = ttl;
     }
 
-    public static OIDCToken of(String token, ProviderType provider, Long id, long ttl) {
+    public static OIDCToken of(String token, ProviderType provider, BigInteger id, long ttl) {
         return OIDCToken.builder()
                 .token(token)
                 .providerWithId(provider.name() + "@" + id)

--- a/src/main/java/com/kcy/fitapet/global/common/redis/oauth/OIDCTokenService.java
+++ b/src/main/java/com/kcy/fitapet/global/common/redis/oauth/OIDCTokenService.java
@@ -11,7 +11,7 @@ public interface OIDCTokenService {
      * @param provider : 제공자
      * @param id : 제공자의 유저 고유번호
      */
-    void saveOIDCToken(String token, ProviderType provider, BigInteger id);
+    void saveOIDCToken(String token, ProviderType provider, String id);
 
     /**
      * OIDC 토큰을 찾아서 반환

--- a/src/main/java/com/kcy/fitapet/global/common/redis/oauth/OIDCTokenService.java
+++ b/src/main/java/com/kcy/fitapet/global/common/redis/oauth/OIDCTokenService.java
@@ -2,6 +2,8 @@ package com.kcy.fitapet.global.common.redis.oauth;
 
 import com.kcy.fitapet.domain.oauth.type.ProviderType;
 
+import java.math.BigInteger;
+
 public interface OIDCTokenService {
     /**
      * OIDC 토큰을 저장
@@ -9,7 +11,7 @@ public interface OIDCTokenService {
      * @param provider : 제공자
      * @param id : 제공자의 유저 고유번호
      */
-    void saveOIDCToken(String token, ProviderType provider, Long id);
+    void saveOIDCToken(String token, ProviderType provider, BigInteger id);
 
     /**
      * OIDC 토큰을 찾아서 반환

--- a/src/main/java/com/kcy/fitapet/global/common/redis/oauth/OIDCTokenServiceImpl.java
+++ b/src/main/java/com/kcy/fitapet/global/common/redis/oauth/OIDCTokenServiceImpl.java
@@ -18,7 +18,7 @@ public class OIDCTokenServiceImpl implements OIDCTokenService {
     private final OIDCTokenRepository oidcTokenRepository;
 
     @Override
-    public void saveOIDCToken(String token, ProviderType provider, BigInteger id) {
+    public void saveOIDCToken(String token, ProviderType provider, String id) {
         final long timeToLive = Duration.ofMinutes(3).toSeconds();
 
         log.info("oidc token ttl : {}", timeToLive);

--- a/src/main/java/com/kcy/fitapet/global/common/redis/oauth/OIDCTokenServiceImpl.java
+++ b/src/main/java/com/kcy/fitapet/global/common/redis/oauth/OIDCTokenServiceImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.math.BigInteger;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
@@ -17,7 +18,7 @@ public class OIDCTokenServiceImpl implements OIDCTokenService {
     private final OIDCTokenRepository oidcTokenRepository;
 
     @Override
-    public void saveOIDCToken(String token, ProviderType provider, Long id) {
+    public void saveOIDCToken(String token, ProviderType provider, BigInteger id) {
         final long timeToLive = Duration.ofMinutes(3).toSeconds();
 
         log.info("oidc token ttl : {}", timeToLive);

--- a/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/JwtSubInfo.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/JwtSubInfo.java
@@ -6,7 +6,7 @@ import java.math.BigInteger;
 
 public interface JwtSubInfo {
     Long id();
-    BigInteger oauthId();
+    String oauthId();
     RoleType role();
     String phoneNumber();
 }

--- a/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/JwtSubInfo.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/JwtSubInfo.java
@@ -2,8 +2,11 @@ package com.kcy.fitapet.global.common.security.jwt.dto;
 
 import com.kcy.fitapet.domain.member.type.RoleType;
 
+import java.math.BigInteger;
+
 public interface JwtSubInfo {
     Long id();
+    BigInteger oauthId();
     RoleType role();
     String phoneNumber();
 }

--- a/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/JwtUserInfo.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/JwtUserInfo.java
@@ -4,6 +4,8 @@ import com.kcy.fitapet.domain.member.domain.Member;
 import com.kcy.fitapet.domain.member.type.RoleType;
 import lombok.Builder;
 
+import java.math.BigInteger;
+
 @Builder
 public record JwtUserInfo  (
         Long id,
@@ -17,6 +19,10 @@ public record JwtUserInfo  (
         return new JwtUserInfo(member.getId(), member.getRole());
     }
 
+    @Override
+    public BigInteger oauthId() {
+        throw new UnsupportedOperationException();
+    }
     @Override
     public String phoneNumber() {
         throw new UnsupportedOperationException();

--- a/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/JwtUserInfo.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/JwtUserInfo.java
@@ -20,7 +20,7 @@ public record JwtUserInfo  (
     }
 
     @Override
-    public BigInteger oauthId() {
+    public String oauthId() {
         throw new UnsupportedOperationException();
     }
     @Override

--- a/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/SmsAuthInfo.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/SmsAuthInfo.java
@@ -15,7 +15,7 @@ public record SmsAuthInfo(
     }
 
     @Override
-    public BigInteger oauthId() {
+    public String oauthId() {
         throw new UnsupportedOperationException();
     }
     @Override

--- a/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/SmsOauthInfo.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/SmsOauthInfo.java
@@ -7,10 +7,10 @@ import java.math.BigInteger;
 
 @Builder
 public record SmsOauthInfo(
-        BigInteger oauthId,
+        String oauthId,
         String phoneNumber
 ) implements JwtSubInfo {
-    public static SmsOauthInfo of(BigInteger id, String phone) {
+    public static SmsOauthInfo of(String id, String phone) {
         return new SmsOauthInfo(id, phone);
     }
 

--- a/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/SmsOauthInfo.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/jwt/dto/SmsOauthInfo.java
@@ -6,18 +6,19 @@ import lombok.Builder;
 import java.math.BigInteger;
 
 @Builder
-public record SmsAuthInfo(
-        Long id,
+public record SmsOauthInfo(
+        BigInteger oauthId,
         String phoneNumber
 ) implements JwtSubInfo {
-    public static SmsAuthInfo of(Long id, String phoneNumber) {
-        return new SmsAuthInfo(id, phoneNumber);
+    public static SmsOauthInfo of(BigInteger id, String phone) {
+        return new SmsOauthInfo(id, phone);
     }
 
     @Override
-    public BigInteger oauthId() {
+    public Long id() {
         throw new UnsupportedOperationException();
     }
+
     @Override
     public RoleType role() {
         throw new UnsupportedOperationException();

--- a/src/main/java/com/kcy/fitapet/global/common/security/jwt/strategy/SmsOauthTokenProvider.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/jwt/strategy/SmsOauthTokenProvider.java
@@ -3,6 +3,7 @@ package com.kcy.fitapet.global.common.security.jwt.strategy;
 import com.kcy.fitapet.global.common.security.jwt.JwtProvider;
 import com.kcy.fitapet.global.common.security.jwt.dto.JwtSubInfo;
 import com.kcy.fitapet.global.common.security.jwt.dto.SmsAuthInfo;
+import com.kcy.fitapet.global.common.security.jwt.dto.SmsOauthInfo;
 import com.kcy.fitapet.global.common.security.jwt.exception.AuthErrorCode;
 import com.kcy.fitapet.global.common.security.jwt.exception.AuthErrorException;
 import com.kcy.fitapet.global.common.security.jwt.exception.JwtErrorCodeUtil;
@@ -17,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.math.BigInteger;
 import java.security.Key;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -64,8 +66,8 @@ public class SmsOauthTokenProvider implements JwtProvider {
     @Override
     public JwtSubInfo getSubInfoFromToken(String token) {
         Claims claims = getClaimsFromToken(token);
-        return SmsAuthInfo.of(
-                claims.get(USER_ID.getValue(), Long.class),
+        return SmsOauthInfo.of(
+                claims.get(USER_ID.getValue(), BigInteger.class),
                 claims.get(PHONE_NUMBER.getValue(), String.class)
         );
     }
@@ -103,7 +105,7 @@ public class SmsOauthTokenProvider implements JwtProvider {
     }
 
     private Map<String, Object> createClaims(JwtSubInfo dto) {
-        return Map.of(USER_ID.getValue(), dto.id(),
+        return Map.of(USER_ID.getValue(), dto.oauthId(),
                 PHONE_NUMBER.getValue(), dto.phoneNumber());
     }
 

--- a/src/main/java/com/kcy/fitapet/global/common/security/jwt/strategy/SmsOauthTokenProvider.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/jwt/strategy/SmsOauthTokenProvider.java
@@ -67,7 +67,7 @@ public class SmsOauthTokenProvider implements JwtProvider {
     public JwtSubInfo getSubInfoFromToken(String token) {
         Claims claims = getClaimsFromToken(token);
         return SmsOauthInfo.of(
-                claims.get(USER_ID.getValue(), BigInteger.class),
+                claims.get(USER_ID.getValue(), String.class),
                 claims.get(PHONE_NUMBER.getValue(), String.class)
         );
     }

--- a/src/main/java/com/kcy/fitapet/global/common/security/oauth/OauthOIDCProviderImpl.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/oauth/OauthOIDCProviderImpl.java
@@ -47,7 +47,7 @@ public class OauthOIDCProviderImpl implements OauthOIDCProvider {
             return Jwts.parserBuilder()
                     .requireAudience(aud)
                     .requireIssuer(iss)
-                    .require("nonce", nonce)
+//                    .require("nonce", nonce)
                     .build()
                     .parseClaimsJwt(getUnsignedToken(token));
         } catch (JwtException e) {

--- a/src/main/java/com/kcy/fitapet/global/common/security/oauth/google/GoogleApplicationConfig.java
+++ b/src/main/java/com/kcy/fitapet/global/common/security/oauth/google/GoogleApplicationConfig.java
@@ -17,11 +17,20 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationPropertiesBinding
 public class GoogleApplicationConfig implements OauthApplicationConfig {
     @NotEmpty
-    private String jwksUri;
+    private String authUri;
     @NotEmpty
     private String clientId;
     @NotEmpty
     private String clientSecret;
     @NotEmpty
     private String clientName;
+
+    @Override
+    public String getJwksUri() {
+        return authUri;
+    }
+
+    public void setJwksUri(String jwksUri) {
+
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -167,9 +167,10 @@ oauth2:
         client-secret: ${KAKAO_CLIENT_SECRET}
         client-name: Kakao
       google:
+        auth-uri: ${GOOGLE_AUTH_URI}
         jwks-uri: ${GOOGLE_JWKS_URI}
-        client-id: "client-id"
-        client-secret: "client-secret"
+        client-id: ${GOOGLE_CLIENT_ID}
+        client-secret: ${GOOGLE_CLIENT_SECRET}
         client-name: Google
       apple:
         jwks-uri: ${APPLE_JWKS_URI}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,9 +59,10 @@ oauth2:
         client-secret: ${KAKAO_CLIENT_SECRET}
         client-name: Kakao
       google:
+        auth-uri: ${GOOGLE_AUTH_URI}
         jwks-uri: ${GOOGLE_JWKS_URI}
         client-id: ${GOOGLE_CLIENT_ID}
-        client-secret: "client-secret"
+        client-secret: ${GOOGLE_CLIENT_SECRET}
         client-name: Google
       apple:
         jwks-uri: ${APPLE_JWKS_URI}


### PR DESCRIPTION
## 작업 이유
- Google oauth 로그인 시, 유저 아이디 값의 범위가 Long을 초과하는 이슈 발생.

## 작업 사항
- Oauth id를 String으로 취급하여 해결

## 이슈 연결
close #73 