### PR TITLE
✨ 반려동물 및 케어 목록 조회 API (기타 부가 API들..)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 
 ### test ###
 src/main/java/com/kcy/fitapet/test/
+src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.0'
 	id 'io.spring.dependency-management' version '1.1.0'
-	id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
+//	id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'com.kcy'
@@ -68,21 +68,14 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 }
 
-// queryDSL 추가 : QueryDSL 빌드 옵션
-def querydslDir = "$buildDir/generated/querydsl"
+def querydslDir = 'src/main/generated'
 
-querydsl {
-	jpa = true
-	querydslSourcesDir = querydslDir
+clean {
+	delete file(querydslDir)
 }
-sourceSets {
-	main.java.srcDir querydslDir
-}
-configurations {
-	querydsl.extendsFrom compileClasspath
-}
-compileQuerydsl {
-	options.annotationProcessorPath = configurations.querydsl
+
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.0'
 	id 'io.spring.dependency-management' version '1.1.0'
+	id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'com.kcy'
@@ -52,6 +53,12 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'io.github.openfeign:feign-okhttp'
 
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	implementation 'mysql:mysql-connector-java:8.0.28'
@@ -59,6 +66,23 @@ dependencies {
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+}
+
+// queryDSL 추가 : QueryDSL 빌드 옵션
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kcy/fitapet/domain/care/api/CareApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/api/CareApi.java
@@ -3,6 +3,7 @@ package com.kcy.fitapet.domain.care.api;
 import com.kcy.fitapet.domain.care.dto.CareInfoRes;
 import com.kcy.fitapet.domain.care.dto.CareSaveReq;
 import com.kcy.fitapet.domain.care.service.component.CareManageService;
+import com.kcy.fitapet.domain.log.dto.CareLogInfo;
 import com.kcy.fitapet.global.common.response.SuccessResponse;
 import com.kcy.fitapet.global.common.security.authentication.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +18,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Tag(name = "Care", description = "케어 API")
@@ -71,4 +74,16 @@ public class CareApi {
         return ResponseEntity.ok(SuccessResponse.from("careCategories", careCategories));
     }
 
+    @Operation(summary = "케어 수행")
+    @GetMapping("/{care_id}/care-dates/{care_date_id}")
+    @PreAuthorize("isAuthenticated() and #userId == principal.userId and @managerAuthorize.isManager(principal.userId, #petId)") // TODO: careDate가 care에 속하는 지 확인
+    public ResponseEntity<?> doCare(
+            @PathVariable("user_id") Long userId,
+            @PathVariable("pet_id") Long petId,
+            @PathVariable("care_id") Long careId,
+            @PathVariable("care_date_id") Long careDateId
+    ) {
+        CareLogInfo careLog = careManageService.doCare(careDateId, userId);
+        return ResponseEntity.ok(SuccessResponse.from(careLog));
+    }
 }

--- a/src/main/java/com/kcy/fitapet/domain/care/api/CareApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/api/CareApi.java
@@ -60,7 +60,7 @@ public class CareApi {
             @PathVariable("pet_id") Long petId
     ) {
         CareInfoRes res = careManageService.findCaresByPetId(petId);
-        return ResponseEntity.ok(SuccessResponse.from("cares", res.getInfo()));
+        return ResponseEntity.ok(SuccessResponse.from("careCategories", res.getInfo()));
     }
 
     @Operation(summary = "작성한 케어 카테고리 목록 조회")

--- a/src/main/java/com/kcy/fitapet/domain/care/api/CareApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/api/CareApi.java
@@ -1,11 +1,13 @@
 package com.kcy.fitapet.domain.care.api;
 
+import com.kcy.fitapet.domain.care.dto.CareInfoRes;
 import com.kcy.fitapet.domain.care.dto.CareSaveReq;
 import com.kcy.fitapet.domain.care.service.component.CareManageService;
 import com.kcy.fitapet.global.common.response.SuccessResponse;
 import com.kcy.fitapet.global.common.security.authentication.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,16 +22,20 @@ import java.util.List;
 @Tag(name = "Care", description = "케어 API")
 @Slf4j
 @RestController
-@RequestMapping("/api/v2/pets/{pet_id}/cares")
+@RequestMapping("/api/v2/users/{user_id}/pets/{pet_id}/cares")
 @RequiredArgsConstructor
 public class CareApi {
     private final CareManageService careManageService;
 
     @Operation(summary = "케어 등록")
-    @Parameter(name = "pet_id", description = "등록할 반려동물 ID", required = true)
+    @Parameters({
+            @Parameter(name = "user_id", description = "등록할 유저 ID", required = true),
+            @Parameter(name = "pet_id", description = "등록할 반려동물 ID", required = true)
+    })
     @PostMapping("")
-    @PreAuthorize("isAuthenticated() && @managerAuthorize.isManager(principal.userId, #petId)")
+    @PreAuthorize("isAuthenticated() and #userId == principal.userId and @managerAuthorize.isManager(principal.userId, #petId)")
     public ResponseEntity<?> saveCare(
+            @PathVariable("user_id") Long userId,
             @PathVariable("pet_id") Long petId,
             @RequestBody @Valid CareSaveReq.Request request,
             @AuthenticationPrincipal CustomUserDetails user
@@ -39,9 +45,24 @@ public class CareApi {
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 
+    @Operation(summary = "케어 목록 조회")
+    @Parameters({
+            @Parameter(name = "user_id", description = "등록할 유저 ID", required = true),
+            @Parameter(name = "pet_id", description = "등록할 반려동물 ID", required = true)
+    })
+    @GetMapping("")
+    @PreAuthorize("isAuthenticated() and #userId == principal.userId and @managerAuthorize.isManager(principal.userId, #petId)")
+    public ResponseEntity<?> getCares(
+            @PathVariable("user_id") Long userId,
+            @PathVariable("pet_id") Long petId
+    ) {
+        CareInfoRes res = careManageService.findCaresByPetId(petId);
+        return ResponseEntity.ok(SuccessResponse.from("cares", res.getInfo()));
+    }
+
     @Operation(summary = "작성한 케어 카테고리 목록 조회")
     @GetMapping("/categories")
-    @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId)")
+    @PreAuthorize("isAuthenticated() and #userId == principal.userId and @managerAuthorize.isManager(principal.userId, #petId)")
     public ResponseEntity<?> getCareCategoryNames(@PathVariable("pet_id") Long petId) {
         List<?> careCategories = careManageService.findCareCategoryNamesByPetId(petId);
         return ResponseEntity.ok(SuccessResponse.from("careCategories", careCategories));

--- a/src/main/java/com/kcy/fitapet/domain/care/api/CareApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/api/CareApi.java
@@ -63,8 +63,12 @@ public class CareApi {
     @Operation(summary = "작성한 케어 카테고리 목록 조회")
     @GetMapping("/categories")
     @PreAuthorize("isAuthenticated() and #userId == principal.userId and @managerAuthorize.isManager(principal.userId, #petId)")
-    public ResponseEntity<?> getCareCategoryNames(@PathVariable("pet_id") Long petId) {
+    public ResponseEntity<?> getCareCategoryNames(
+            @PathVariable("user_id") Long userId,
+            @PathVariable("pet_id") Long petId
+    ) {
         List<?> careCategories = careManageService.findCareCategoryNamesByPetId(petId);
         return ResponseEntity.ok(SuccessResponse.from("careCategories", careCategories));
     }
+
 }

--- a/src/main/java/com/kcy/fitapet/domain/care/dao/CareDateRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/dao/CareDateRepository.java
@@ -2,7 +2,7 @@ package com.kcy.fitapet.domain.care.dao;
 
 import com.kcy.fitapet.domain.care.domain.CareDate;
 import com.kcy.fitapet.global.common.repository.ExtendedRepository;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CareDateRepository extends ExtendedRepository<CareDate, Long> {
+
 }

--- a/src/main/java/com/kcy/fitapet/domain/care/dao/CareDateRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/dao/CareDateRepository.java
@@ -1,8 +1,11 @@
 package com.kcy.fitapet.domain.care.dao;
 
 import com.kcy.fitapet.domain.care.domain.CareDate;
+import com.kcy.fitapet.domain.care.type.WeekType;
 import com.kcy.fitapet.global.common.repository.ExtendedRepository;
 
-public interface CareDateRepository extends ExtendedRepository<CareDate, Long> {
+import java.util.List;
 
+public interface CareDateRepository extends ExtendedRepository<CareDate, Long> {
+    List<CareDate> findAllByCare_IdAndWeek(Long careId, WeekType week);
 }

--- a/src/main/java/com/kcy/fitapet/domain/care/domain/CareDate.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/domain/CareDate.java
@@ -2,6 +2,7 @@ package com.kcy.fitapet.domain.care.domain;
 
 import com.kcy.fitapet.domain.care.type.WeekType;
 import com.kcy.fitapet.domain.care.type.WeekTypeConverter;
+import com.kcy.fitapet.domain.log.domain.CareLog;
 import com.kcy.fitapet.domain.model.DateAuditable;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,6 +11,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "CARE_DATE")
@@ -26,6 +29,8 @@ public class CareDate extends DateAuditable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "care_id")
     private Care care;
+    @OneToMany(mappedBy = "careDate", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CareLog> careLogs = new ArrayList<>();
 
     @Builder
     private CareDate(WeekType week, LocalTime careTime) {
@@ -46,6 +51,10 @@ public class CareDate extends DateAuditable {
         }
         this.care = care;
         care.getCareDates().add(this);
+    }
+
+    public boolean checkToday() {
+        return week.checkToday();
     }
 
     @Override public String toString() {

--- a/src/main/java/com/kcy/fitapet/domain/care/dto/CareInfoRes.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/dto/CareInfoRes.java
@@ -1,0 +1,34 @@
+package com.kcy.fitapet.domain.care.dto;
+
+import com.kcy.fitapet.domain.care.domain.CareCategory;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class CareInfoRes {
+    private List<?> info = new ArrayList<>();
+
+    public static CareInfoRes from(List<CareCategory> careCategories) {
+        CareInfoRes careInfoRes = new CareInfoRes();
+        careInfoRes.info = careCategories;
+        return careInfoRes;
+    }
+
+    public record CareCategoryDto(
+        Long id,
+        String categoryName,
+        List<CareDto> cares
+    ) {
+
+    }
+
+    public record CareDto(
+            Long id,
+            String careName,
+            boolean isClear
+    ) {
+
+    }
+}

--- a/src/main/java/com/kcy/fitapet/domain/care/dto/CareInfoRes.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/dto/CareInfoRes.java
@@ -10,25 +10,30 @@ import java.util.List;
 public class CareInfoRes {
     private List<?> info = new ArrayList<>();
 
-    public static CareInfoRes from(List<CareCategory> careCategories) {
+    public static CareInfoRes from(List<CareCategoryDto> careCategories) {
         CareInfoRes careInfoRes = new CareInfoRes();
         careInfoRes.info = careCategories;
         return careInfoRes;
     }
 
     public record CareCategoryDto(
-        Long id,
+        Long careCategoryId,
         String categoryName,
         List<CareDto> cares
     ) {
-
+        public static CareCategoryDto of(Long id, String categoryName, List<CareDto> cares) {
+            return new CareCategoryDto(id, categoryName, cares);
+        }
     }
 
     public record CareDto(
-            Long id,
+            Long careId,
+            Long careDateId,
             String careName,
             boolean isClear
     ) {
-
+        public static CareDto of(Long careId, Long careDateId, String careName, boolean isClear) {
+            return new CareDto(careId, careDateId, careName, isClear);
+        }
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/care/dto/CareInfoRes.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/dto/CareInfoRes.java
@@ -3,6 +3,9 @@ package com.kcy.fitapet.domain.care.dto;
 import com.kcy.fitapet.domain.care.domain.CareCategory;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,10 +33,11 @@ public class CareInfoRes {
             Long careId,
             Long careDateId,
             String careName,
+            String careDate,
             boolean isClear
     ) {
-        public static CareDto of(Long careId, Long careDateId, String careName, boolean isClear) {
-            return new CareDto(careId, careDateId, careName, isClear);
+        public static CareDto of(Long careId, Long careDateId, String careName, LocalTime careDate, boolean isClear) {
+            return new CareDto(careId, careDateId, careName, careDate.format(DateTimeFormatter.ofPattern("HH:mm:ss")), isClear);
         }
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/care/dto/CareSaveReq.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/dto/CareSaveReq.java
@@ -52,7 +52,7 @@ public class CareSaveReq {
             @NotBlank
             String careName,
             @NotNull
-            List<CareDateDto> careDate,
+            List<CareDateDto> careDates,
             @Schema(description = "제한 시간(분 단위) - 제한 시간 없는 경우 0", example = "30")
             @NotNull
             Integer limitTime
@@ -62,7 +62,7 @@ public class CareSaveReq {
         }
 
         public List<CareDate> toCareDateEntity() {
-            return careDate.stream()
+            return careDates.stream()
                     .map(careDateDto -> CareDate.of(careDateDto.week(), careDateDto.time()))
                     .collect(toMap(CareDate::getWeek, careDate -> careDate, (o1, o2) -> o1))
                     .values()

--- a/src/main/java/com/kcy/fitapet/domain/care/exception/CareErrorCode.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/exception/CareErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum CareErrorCode implements StatusCode {
     /* 400 BAD_REQUEST */
     CATEGORY_STATUS_INVALID(HttpStatus.BAD_REQUEST, "카테고리를 생성할 수 없는 상태입니다."),
-
+    ALREADY_CARED(HttpStatus.BAD_REQUEST, "이미 케어한 날짜에 대한 요청"),
+    NOT_TODAY_CARE(HttpStatus.BAD_REQUEST, "오늘 날짜에 대한 요청이 아님")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/kcy/fitapet/domain/care/service/component/CareManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/service/component/CareManageService.java
@@ -69,12 +69,10 @@ public class CareManageService {
             List<Care> cares = careCategory.getCares();
 
             for (Care care : cares) {
-                log.info("care: {}", care);
-//                String today = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-                LocalDate today = LocalDate.now();
+                LocalDateTime today = LocalDateTime.now();
                 log.info("today: {}", today);
 
-                boolean isClear = careLogSearchService.existsByCareIdOnToday(care.getId(), today);
+                boolean isClear = careLogSearchService.existsByCareIdOnLogDate(care.getId(), today);
                 log.info("isClear: {}", isClear);
             }
         }

--- a/src/main/java/com/kcy/fitapet/domain/care/service/component/CareManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/service/component/CareManageService.java
@@ -6,6 +6,7 @@ import com.kcy.fitapet.domain.care.domain.CareDate;
 import com.kcy.fitapet.domain.care.dto.CareCategoryDto;
 import com.kcy.fitapet.domain.care.dto.CareInfoRes;
 import com.kcy.fitapet.domain.care.dto.CareSaveReq;
+import com.kcy.fitapet.domain.care.exception.CareErrorCode;
 import com.kcy.fitapet.domain.care.service.module.CareSaveService;
 import com.kcy.fitapet.domain.care.service.module.CareSearchService;
 import com.kcy.fitapet.domain.care.type.WeekType;
@@ -66,7 +67,7 @@ public class CareManageService {
                     boolean isClear = careLogSearchService.existsByCareDateIdOnLogDate(careDate.getId(), today);
                     log.info("isClear: {}", isClear);
 
-                    careDtos.add(CareInfoRes.CareDto.of(care.getId(), careDate.getId(), care.getCareName(), isClear));
+                    careDtos.add(CareInfoRes.CareDto.of(care.getId(), careDate.getId(), care.getCareName(), careDate.getCareTime(), isClear));
                 }
             }
 
@@ -81,7 +82,7 @@ public class CareManageService {
 
         if (!careDate.getWeek().checkToday()) {
             log.warn("오늘 날짜에 대한 요청이 아닙니다. {} <- 요청 : {}", careDate.getWeek(), LocalDateTime.now().getDayOfWeek());
-            throw new GlobalErrorException(PetErrorCode.NOT_TODAY_CARE);
+            throw new GlobalErrorException(CareErrorCode.NOT_TODAY_CARE);
         }
 
         // TODO: 케어 등록 시간 10분 전부터 수행할 수 있도록 조건 추가?
@@ -89,7 +90,7 @@ public class CareManageService {
         LocalDateTime today = LocalDateTime.now();
         if (careLogSearchService.existsByCareDateIdOnLogDate(careDateId, today)) {
             log.warn("이미 케어를 수행한 기록이 존재합니다.");
-            throw new GlobalErrorException(PetErrorCode.ALREADY_CARED);
+            throw new GlobalErrorException(CareErrorCode.ALREADY_CARED);
         }
 
         CareLog careLog = careLogSaveService.save(CareLog.of(careDate));

--- a/src/main/java/com/kcy/fitapet/domain/care/service/module/CareSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/service/module/CareSearchService.java
@@ -3,7 +3,9 @@ package com.kcy.fitapet.domain.care.service.module;
 import com.kcy.fitapet.domain.care.dao.CareCategoryRepository;
 import com.kcy.fitapet.domain.care.dao.CareDateRepository;
 import com.kcy.fitapet.domain.care.dao.CareRepository;
+import com.kcy.fitapet.domain.care.domain.Care;
 import com.kcy.fitapet.domain.care.domain.CareCategory;
+import com.kcy.fitapet.domain.care.domain.CareDate;
 import com.kcy.fitapet.domain.care.dto.CareCategoryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,16 @@ public class CareSearchService {
     private final CareRepository careRepository;
     private final CareCategoryRepository careCategoryRepository;
     private final CareDateRepository careDateRepository;
+
+    @Transactional(readOnly = true)
+    public Care findCareById(Long careId) {
+        return careRepository.findByIdOrElseThrow(careId);
+    }
+
+    @Transactional(readOnly = true)
+    public CareDate findCareDateById(Long careDateId) {
+        return careDateRepository.findByIdOrElseThrow(careDateId);
+    }
 
     @Transactional(readOnly = true)
     public CareCategory findCareCategoryById(Long categoryId) {

--- a/src/main/java/com/kcy/fitapet/domain/care/service/module/CareSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/service/module/CareSearchService.java
@@ -7,6 +7,7 @@ import com.kcy.fitapet.domain.care.domain.Care;
 import com.kcy.fitapet.domain.care.domain.CareCategory;
 import com.kcy.fitapet.domain.care.domain.CareDate;
 import com.kcy.fitapet.domain.care.dto.CareCategoryDto;
+import com.kcy.fitapet.domain.care.type.WeekType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +29,11 @@ public class CareSearchService {
     @Transactional(readOnly = true)
     public CareDate findCareDateById(Long careDateId) {
         return careDateRepository.findByIdOrElseThrow(careDateId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CareDate> findCareDatesCareIdAndWeek(Long careId, WeekType week) {
+        return careDateRepository.findAllByCare_IdAndWeek(careId, week);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/kcy/fitapet/domain/care/type/WeekType.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/type/WeekType.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.kcy.fitapet.global.common.util.converter.LegacyCommonType;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -12,16 +13,17 @@ import static java.util.stream.Collectors.toMap;
 
 @RequiredArgsConstructor
 public enum WeekType implements LegacyCommonType {
-    MON("1", "월"),
-    TUE("2", "화"),
-    WED("3", "수"),
-    THU("4", "목"),
-    FRI("5", "금"),
-    SAT("6", "토"),
-    SUN("7", "일");
+    MON("1", "월", "MONDAY"),
+    TUE("2", "화", "TUESDAY"),
+    WED("3", "수", "WEDNESDAY"),
+    THU("4", "목", "THURSDAY"),
+    FRI("5", "금", "FRIDAY"),
+    SAT("6", "토", "SATURDAY"),
+    SUN("7", "일", "SUNDAY");
 
     private final String code;
     private final String type;
+    private final String legacyType;
 
     private static final Map<String, WeekType> stringToEnum =
             Stream.of(values()).collect(toMap(Object::toString, e -> e));
@@ -37,7 +39,17 @@ public enum WeekType implements LegacyCommonType {
     public static WeekType fromString(String type) {
         return stringToEnum.get(type.toUpperCase());
     }
+    public static WeekType fromLegacyType(String legacyType) {
+        return Stream.of(values())
+                .filter(weekType -> weekType.legacyType.equals(legacyType.toUpperCase()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No such type: " + legacyType));
+    }
     @Override public String toString() {
         return type;
+    }
+
+    public boolean checkToday() {
+        return this.equals(fromLegacyType(LocalDate.now().getDayOfWeek().toString()));
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/log/dao/CareLogQueryRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/dao/CareLogQueryRepository.java
@@ -1,0 +1,7 @@
+package com.kcy.fitapet.domain.log.dao;
+
+import java.time.LocalDateTime;
+
+public interface CareLogQueryRepository {
+    boolean existsByCareDateIdAndLogDate(Long careDateId, LocalDateTime logDate);
+}

--- a/src/main/java/com/kcy/fitapet/domain/log/dao/CareLogQueryRepositoryImpl.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/dao/CareLogQueryRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.kcy.fitapet.domain.log.dao;
+
+import com.kcy.fitapet.domain.log.domain.QCareLog;
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Repository
+@RequiredArgsConstructor
+public class CareLogQueryRepositoryImpl implements CareLogQueryRepository {
+    private final JPAQueryFactory queryFactory;
+    private QCareLog careLog = QCareLog.careLog;
+
+    @Override
+    public boolean existsByCareDateIdAndLogDate(Long careDateId, LocalDateTime logDate) {
+        return queryFactory.selectFrom(careLog)
+                .where(careLog.careDate.id.eq(careDateId)
+                        .and(careLog.logDate.between(
+                            Expressions.asDateTime(logDate),
+                            Expressions.asDateTime(logDate.plusDays(1L).minusSeconds(1L))
+                        ))
+                        )
+                .fetchFirst() != null;
+    }
+
+}

--- a/src/main/java/com/kcy/fitapet/domain/log/dao/CareLogQueryRepositoryImpl.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/dao/CareLogQueryRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -13,17 +14,21 @@ import java.time.format.DateTimeFormatter;
 
 @Repository
 @RequiredArgsConstructor
+@Slf4j
 public class CareLogQueryRepositoryImpl implements CareLogQueryRepository {
     private final JPAQueryFactory queryFactory;
     private QCareLog careLog = QCareLog.careLog;
 
     @Override
     public boolean existsByCareDateIdAndLogDate(Long careDateId, LocalDateTime logDate) {
+        log.info("start: {}", Expressions.asDateTime(logDate.withHour(0).withMinute(0).withSecond(0)));
+        log.info("end: {}", Expressions.asDateTime(logDate.withHour(23).withMinute(59).withSecond(59)));
+
         return queryFactory.selectFrom(careLog)
                 .where(careLog.careDate.id.eq(careDateId)
                         .and(careLog.logDate.between(
-                            Expressions.asDateTime(logDate),
-                            Expressions.asDateTime(logDate.plusDays(1L).minusSeconds(1L))
+                            Expressions.asDateTime(logDate.withHour(0).withMinute(0).withSecond(0)),
+                            Expressions.asDateTime(logDate.withHour(23).withMinute(59).withSecond(59))
                         ))
                         )
                 .fetchFirst() != null;

--- a/src/main/java/com/kcy/fitapet/domain/log/dao/CareLogRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/dao/CareLogRepository.java
@@ -4,5 +4,8 @@ import com.kcy.fitapet.domain.log.domain.CareLog;
 import com.kcy.fitapet.domain.log.domain.CareLogId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+
 public interface CareLogRepository extends JpaRepository<CareLog, CareLogId> {
+    boolean existsByCareDate_IdAndLogDate(Long careId, LocalDate today);
 }

--- a/src/main/java/com/kcy/fitapet/domain/log/domain/CareLog.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/domain/CareLog.java
@@ -5,6 +5,7 @@ import com.kcy.fitapet.domain.care.domain.CareDate;
 import com.kcy.fitapet.domain.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -13,6 +14,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = "CARE_LOG")
 @IdClass(CareLogId.class)
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -33,4 +35,19 @@ public class CareLog {
     @JoinColumn(name = "author_id", nullable = false, updatable = false)
     @JsonIgnore
     private Member author;
+
+    public static CareLog of(CareDate careDate) {
+        CareLog careLog = new CareLog();
+        careLog.setCareDate(careDate);
+        return careLog;
+    }
+
+    public void setCareDate(CareDate careDate) {
+        if (this.careDate != null) {
+            this.careDate.getCareLogs().remove(this);
+        }
+
+        this.careDate = careDate;
+        careDate.getCareLogs().add(this);
+    }
 }

--- a/src/main/java/com/kcy/fitapet/domain/log/domain/CareLog.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/domain/CareLog.java
@@ -1,6 +1,7 @@
 package com.kcy.fitapet.domain.log.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.kcy.fitapet.domain.care.domain.CareDate;
 import com.kcy.fitapet.domain.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -23,19 +24,13 @@ public class CareLog {
     @Id @CreatedDate
     private LocalDateTime logDate;
 
-    private Long careDateId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "care_date_id", nullable = false, updatable = false)
+    private CareDate careDate;
 
     @CreatedBy
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id", nullable = false, updatable = false)
     @JsonIgnore
     private Member author;
-
-    private CareLog(Long careDateId) {
-        this.careDateId = careDateId;
-    }
-
-    public static CareLog of(Long careDateId) {
-        return new CareLog(careDateId);
-    }
 }

--- a/src/main/java/com/kcy/fitapet/domain/log/domain/CareLogId.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/domain/CareLogId.java
@@ -1,9 +1,11 @@
 package com.kcy.fitapet.domain.log.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Transient;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -15,6 +17,8 @@ public class CareLogId implements Serializable {
     @Transient
     private static final long serialVersionUID = 1L;
 
+    @Column(name = "id")
     private Long id;
+    @Column(name = "log_date")
     private LocalDateTime logDate;
 }

--- a/src/main/java/com/kcy/fitapet/domain/log/dto/CareLogInfo.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/dto/CareLogInfo.java
@@ -5,15 +5,16 @@ import com.kcy.fitapet.domain.member.domain.Member;
 import com.kcy.fitapet.global.common.util.bind.Dto;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Dto(name = "careLog")
 public record CareLogInfo(
-        LocalDateTime logDate,
+        String logDate,
         String uid
 ) {
     public static CareLogInfo of(LocalDateTime logDate, String uid) {
         return new CareLogInfo(
-                logDate,
+                logDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
                 uid
         );
     }

--- a/src/main/java/com/kcy/fitapet/domain/log/dto/CareLogInfo.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/dto/CareLogInfo.java
@@ -1,0 +1,20 @@
+package com.kcy.fitapet.domain.log.dto;
+
+import com.kcy.fitapet.domain.log.domain.CareLog;
+import com.kcy.fitapet.domain.member.domain.Member;
+import com.kcy.fitapet.global.common.util.bind.Dto;
+
+import java.time.LocalDateTime;
+
+@Dto(name = "careLog")
+public record CareLogInfo(
+        LocalDateTime logDate,
+        String uid
+) {
+    public static CareLogInfo of(LocalDateTime logDate, String uid) {
+        return new CareLogInfo(
+                logDate,
+                uid
+        );
+    }
+}

--- a/src/main/java/com/kcy/fitapet/domain/log/service/CareLogSaveService.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/service/CareLogSaveService.java
@@ -1,0 +1,17 @@
+package com.kcy.fitapet.domain.log.service;
+
+import com.kcy.fitapet.domain.care.domain.Care;
+import com.kcy.fitapet.domain.log.dao.CareLogRepository;
+import com.kcy.fitapet.domain.log.domain.CareLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CareLogSaveService {
+    private final CareLogRepository careLogRepository;
+
+    public CareLog save(CareLog careLog) {
+        return careLogRepository.save(careLog);
+    }
+}

--- a/src/main/java/com/kcy/fitapet/domain/log/service/CareLogSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/service/CareLogSearchService.java
@@ -16,7 +16,7 @@ public class CareLogSearchService {
     private final CareLogQueryRepository careLogQueryRepository;
 
     @Transactional(readOnly = true)
-    public boolean existsByCareIdOnLogDate(Long careId, LocalDateTime date) {
-        return careLogQueryRepository.existsByCareDateIdAndLogDate(careId, date);
+    public boolean existsByCareDateIdOnLogDate(Long careDateId, LocalDateTime date) {
+        return careLogQueryRepository.existsByCareDateIdAndLogDate(careDateId, date);
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/log/service/CareLogSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/service/CareLogSearchService.java
@@ -1,19 +1,22 @@
 package com.kcy.fitapet.domain.log.service;
 
+import com.kcy.fitapet.domain.log.dao.CareLogQueryRepository;
 import com.kcy.fitapet.domain.log.dao.CareLogRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class CareLogSearchService {
     private final CareLogRepository careLogRepository;
+    private final CareLogQueryRepository careLogQueryRepository;
 
     @Transactional(readOnly = true)
-    public boolean existsByCareIdOnToday(Long careId, LocalDate today) {
-        return careLogRepository.existsByCareDate_IdAndLogDate(careId, today);
+    public boolean existsByCareIdOnLogDate(Long careId, LocalDateTime date) {
+        return careLogQueryRepository.existsByCareDateIdAndLogDate(careId, date);
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/log/service/CareLogSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/service/CareLogSearchService.java
@@ -1,0 +1,19 @@
+package com.kcy.fitapet.domain.log.service;
+
+import com.kcy.fitapet.domain.log.dao.CareLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class CareLogSearchService {
+    private final CareLogRepository careLogRepository;
+
+    @Transactional(readOnly = true)
+    public boolean existsByCareIdOnToday(Long careId, LocalDate today) {
+        return careLogRepository.existsByCareDate_IdAndLogDate(careId, today);
+    }
+}

--- a/src/main/java/com/kcy/fitapet/domain/member/api/AccountApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/api/AccountApi.java
@@ -7,6 +7,7 @@ import com.kcy.fitapet.domain.member.dto.account.UidRes;
 import com.kcy.fitapet.domain.member.service.component.MemberAccountService;
 import com.kcy.fitapet.domain.member.type.MemberAttrType;
 import com.kcy.fitapet.domain.notification.type.NotificationType;
+import com.kcy.fitapet.domain.pet.dto.PetInfoRes;
 import com.kcy.fitapet.global.common.response.SuccessResponse;
 import com.kcy.fitapet.global.common.security.authentication.CustomUserDetails;
 import com.kcy.fitapet.global.common.redis.sms.type.SmsPrefix;
@@ -105,5 +106,13 @@ public class AccountApi {
             @RequestParam("type") @NotBlank NotificationType type) {
         memberAccountService.updateNotification(id, user.getUserId(), type);
         return ResponseEntity.ok(SuccessResponse.noContent());
+    }
+
+    @Operation(summary = "관리 중인 반려동물 pk 리스트 조회")
+    @GetMapping("/{id}/pets")
+    @PreAuthorize("isAuthenticated() and #id == principal.userId")
+    public ResponseEntity<?> getPetIds(@PathVariable Long id) {
+        List<Long> petIds = memberAccountService.getPetIds(id);
+        return ResponseEntity.ok(SuccessResponse.from("pets", petIds));
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/member/api/AccountApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/api/AccountApi.java
@@ -108,11 +108,11 @@ public class AccountApi {
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 
-    @Operation(summary = "관리 중인 반려동물 pk 리스트 조회")
+    @Operation(summary = "관리 중인 반려동물 리스트 조회")
     @GetMapping("/{id}/pets")
     @PreAuthorize("isAuthenticated() and #id == principal.userId")
     public ResponseEntity<?> getPetIds(@PathVariable Long id) {
-        List<Long> petIds = memberAccountService.getPetIds(id);
-        return ResponseEntity.ok(SuccessResponse.from("pets", petIds));
+        PetInfoRes pets = memberAccountService.getPetIds(id);
+        return ResponseEntity.ok(SuccessResponse.from("pets", pets.getPets()));
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/member/api/AccountApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/api/AccountApi.java
@@ -107,12 +107,4 @@ public class AccountApi {
         memberAccountService.updateNotification(id, user.getUserId(), type);
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
-
-    @Operation(summary = "관리 중인 반려동물 리스트 조회")
-    @GetMapping("/{id}/pets")
-    @PreAuthorize("isAuthenticated() and #id == principal.userId")
-    public ResponseEntity<?> getPetIds(@PathVariable Long id) {
-        PetInfoRes pets = memberAccountService.getPetIds(id);
-        return ResponseEntity.ok(SuccessResponse.from("pets", pets.getPets()));
-    }
 }

--- a/src/main/java/com/kcy/fitapet/domain/member/api/AuthApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/api/AuthApi.java
@@ -191,6 +191,14 @@ public class AuthApi {
         return getResponseEntity(tokens);
     }
 
+    @Operation(summary = "토큰 검증", description = "액세스 토큰의 유효성을 검사합니다.")
+    @Parameter(name = "Authorization", description = "액세스 토큰", in = ParameterIn.HEADER)
+    @GetMapping("/verify")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> verify(@AccessTokenInfo AccessToken accessToken) {
+        return ResponseEntity.ok(SuccessResponse.from("userId", accessToken.userId()));
+    }
+
     /**
      * 액세스 토큰과 리프레시 토큰을 반환합니다.
      * @param tokens : 액세스 토큰과 리프레시 토큰

--- a/src/main/java/com/kcy/fitapet/domain/member/dto/account/AccountProfileRes.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/dto/account/AccountProfileRes.java
@@ -5,6 +5,7 @@ import com.kcy.fitapet.domain.member.domain.NotificationSetting;
 import com.kcy.fitapet.global.common.util.bind.Dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import org.springframework.util.StringUtils;
 
 @Schema(description = "회원 프로필 조회 응답")
 @Builder
@@ -37,8 +38,8 @@ public record AccountProfileRes(
                         .id(member.getId())
                         .name(member.getName())
                         .uid(member.getUid())
-                        .email(member.getEmail())
-                        .profileImage(member.getProfileImg())
+                        .email(StringUtils.hasText(member.getEmail()) ? member.getEmail() : "")
+                        .profileImage(StringUtils.hasText(member.getProfileImg()) ? member.getProfileImg() : "")
                         .isNotice(setting.getIsNotice())
                         .isCare(setting.getIsCare())
                         .isMemo(setting.getIsMemo())

--- a/src/main/java/com/kcy/fitapet/domain/member/dto/auth/SignUpReq.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/dto/auth/SignUpReq.java
@@ -2,9 +2,11 @@ package com.kcy.fitapet.domain.member.dto.auth;
 
 import com.kcy.fitapet.domain.member.domain.Member;
 import com.kcy.fitapet.domain.member.type.RoleType;
+import io.netty.util.internal.StringUtil;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.util.StringUtils;
 
 @Schema(description = "회원가입 요청")
 public record SignUpReq(
@@ -24,9 +26,9 @@ public record SignUpReq(
                 .uid(uid)
                 .password(password)
                 .name(name)
-                .email(email)
+                .email(StringUtils.hasText(email) ? email : null)
                 .phone(phone)
-                .profileImg(profileImg)
+                .profileImg(StringUtils.hasText(profileImg) ? profileImg : null)
                 .accountLocked(Boolean.FALSE)
                 .role(RoleType.USER)
                 .build();

--- a/src/main/java/com/kcy/fitapet/domain/member/service/component/MemberAccountService.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/service/component/MemberAccountService.java
@@ -1,5 +1,6 @@
 package com.kcy.fitapet.domain.member.service.component;
 
+import com.kcy.fitapet.domain.member.domain.Manager;
 import com.kcy.fitapet.domain.member.domain.Member;
 import com.kcy.fitapet.domain.member.dto.account.AccountProfileRes;
 import com.kcy.fitapet.domain.member.dto.account.AccountSearchReq;
@@ -10,6 +11,9 @@ import com.kcy.fitapet.domain.member.exception.SmsErrorCode;
 import com.kcy.fitapet.domain.member.service.module.MemberSearchService;
 import com.kcy.fitapet.domain.member.type.MemberAttrType;
 import com.kcy.fitapet.domain.notification.type.NotificationType;
+import com.kcy.fitapet.domain.pet.domain.Pet;
+import com.kcy.fitapet.domain.pet.dto.PetInfoRes;
+import com.kcy.fitapet.domain.pet.service.module.PetSearchService;
 import com.kcy.fitapet.global.common.redis.sms.SmsRedisHelper;
 import com.kcy.fitapet.global.common.redis.sms.type.SmsPrefix;
 import com.kcy.fitapet.global.common.response.code.StatusCode;
@@ -21,11 +25,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class MemberAccountService {
     private final MemberSearchService memberSearchService;
+    private final PetSearchService petSearchService;
+
     private final SmsRedisHelper smsRedisHelper;
 
     private final PasswordEncoder bCryptPasswordEncoder;
@@ -82,6 +90,13 @@ public class MemberAccountService {
     public void updateNotification(Long requestId, Long userId, NotificationType type) {
         Member member = memberSearchService.findById(userId);
         member.updateNotificationFromType(type);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> getPetIds(Long userId) {
+        List<Manager> managers = memberSearchService.findAllManagerByMemberId(userId);
+        List<Pet> pets = managers.stream().map(Manager::getPet).toList();
+        return pets.stream().map(Pet::getId).toList();
     }
 
     /**

--- a/src/main/java/com/kcy/fitapet/domain/member/service/component/MemberAccountService.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/service/component/MemberAccountService.java
@@ -93,10 +93,10 @@ public class MemberAccountService {
     }
 
     @Transactional(readOnly = true)
-    public List<Long> getPetIds(Long userId) {
+    public PetInfoRes getPetIds(Long userId) {
         List<Manager> managers = memberSearchService.findAllManagerByMemberId(userId);
         List<Pet> pets = managers.stream().map(Manager::getPet).toList();
-        return pets.stream().map(Pet::getId).toList();
+        return PetInfoRes.ofPetInfo(pets);
     }
 
     /**

--- a/src/main/java/com/kcy/fitapet/domain/member/service/component/MemberAccountService.java
+++ b/src/main/java/com/kcy/fitapet/domain/member/service/component/MemberAccountService.java
@@ -32,7 +32,6 @@ import java.util.List;
 @Slf4j
 public class MemberAccountService {
     private final MemberSearchService memberSearchService;
-    private final PetSearchService petSearchService;
 
     private final SmsRedisHelper smsRedisHelper;
 
@@ -90,13 +89,6 @@ public class MemberAccountService {
     public void updateNotification(Long requestId, Long userId, NotificationType type) {
         Member member = memberSearchService.findById(userId);
         member.updateNotificationFromType(type);
-    }
-
-    @Transactional(readOnly = true)
-    public PetInfoRes getPetIds(Long userId) {
-        List<Manager> managers = memberSearchService.findAllManagerByMemberId(userId);
-        List<Pet> pets = managers.stream().map(Manager::getPet).toList();
-        return PetInfoRes.ofPetInfo(pets);
     }
 
     /**

--- a/src/main/java/com/kcy/fitapet/domain/pet/api/PetApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/api/PetApi.java
@@ -1,6 +1,7 @@
 package com.kcy.fitapet.domain.pet.api;
 
 import com.kcy.fitapet.domain.care.dto.CareCategoryDto;
+import com.kcy.fitapet.domain.pet.dto.PetInfoRes;
 import com.kcy.fitapet.domain.pet.dto.PetSaveReq;
 import com.kcy.fitapet.domain.pet.service.component.PetManageService;
 import com.kcy.fitapet.global.common.response.ErrorResponse;
@@ -48,6 +49,14 @@ public class PetApi {
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 
+    @Operation(summary = "관리 중인 반려동물 리스트 조회")
+    @GetMapping("")
+    @PreAuthorize("isAuthenticated() and #userId == principal.userId")
+    public ResponseEntity<?> getPets(@PathVariable("user_id") Long userId) {
+        PetInfoRes pets = petManageService.getPets(userId);
+        return ResponseEntity.ok(SuccessResponse.from("pets", pets.getPets()));
+    }
+
     @Operation(summary = "관리 중인 반려동물 목록 조회")
     @Parameter(name = "user_id", description = "조회할 유저 ID", required = true)
     @GetMapping("/summary")
@@ -65,4 +74,6 @@ public class PetApi {
         List<?> result = petManageService.checkCategoryExist(userId, request.categoryName(), request.pets());
         return ResponseEntity.ok(SuccessResponse.from("categories", result));
     }
+
+
 }

--- a/src/main/java/com/kcy/fitapet/domain/pet/api/PetApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/api/PetApi.java
@@ -1,7 +1,7 @@
 package com.kcy.fitapet.domain.pet.api;
 
 import com.kcy.fitapet.domain.care.dto.CareCategoryDto;
-import com.kcy.fitapet.domain.pet.dto.PetRegisterReq;
+import com.kcy.fitapet.domain.pet.dto.PetSaveReq;
 import com.kcy.fitapet.domain.pet.service.component.PetManageService;
 import com.kcy.fitapet.global.common.response.ErrorResponse;
 import com.kcy.fitapet.global.common.response.FailureResponse;
@@ -42,7 +42,7 @@ public class PetApi {
     })
     @PostMapping("")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> savePet(@RequestBody @Valid PetRegisterReq req, @AuthenticationPrincipal CustomUserDetails user) {
+    public ResponseEntity<?> savePet(@RequestBody @Valid PetSaveReq req, @AuthenticationPrincipal CustomUserDetails user) {
         petManageService.savePet(req.toPetEntity(), user.getUserId());
 
         return ResponseEntity.ok(SuccessResponse.noContent());
@@ -65,5 +65,4 @@ public class PetApi {
         List<?> result = petManageService.checkCategoryExist(userId, request.categoryName(), request.pets());
         return ResponseEntity.ok(SuccessResponse.from("categories", result));
     }
-
 }

--- a/src/main/java/com/kcy/fitapet/domain/pet/dto/PetInfoRes.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/dto/PetInfoRes.java
@@ -20,7 +20,12 @@ public class PetInfoRes {
         return petInfoRes;
     }
 
-    @Dto(name = "pet")
+    public static PetInfoRes ofPetIds(List<Pet> pets) {
+        PetInfoRes petInfoRes = new PetInfoRes();
+        petInfoRes.pets = pets.stream().map(PetIds::of).toList();
+        return petInfoRes;
+    }
+
     private record PetSummaryInfo(
             Long id,
             String petName,

--- a/src/main/java/com/kcy/fitapet/domain/pet/dto/PetInfoRes.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/dto/PetInfoRes.java
@@ -2,9 +2,12 @@ package com.kcy.fitapet.domain.pet.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.kcy.fitapet.domain.care.domain.CareCategory;
 import com.kcy.fitapet.domain.pet.domain.Pet;
+import com.kcy.fitapet.domain.pet.type.GenderType;
 import com.kcy.fitapet.global.common.util.bind.Dto;
 import lombok.Getter;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,9 +23,9 @@ public class PetInfoRes {
         return petInfoRes;
     }
 
-    public static PetInfoRes ofPetIds(List<Pet> pets) {
+    public static PetInfoRes ofPetInfo(List<Pet> pets) {
         PetInfoRes petInfoRes = new PetInfoRes();
-        petInfoRes.pets = pets.stream().map(PetIds::of).toList();
+        petInfoRes.pets = pets.stream().map(PetInfo::from).toList();
         return petInfoRes;
     }
 
@@ -36,6 +39,26 @@ public class PetInfoRes {
                     pet.getId(),
                     pet.getPetName(),
                     pet.getPetProfileImg()
+            );
+        }
+    }
+
+    private record PetInfo(
+            Long id,
+            String petName,
+            GenderType gender,
+            String petProfileImage,
+            String feed,
+            List<Long> careIds
+    ) {
+        private static PetInfo from(Pet pet) {
+            return new PetInfo(
+                    pet.getId(),
+                    pet.getPetName(),
+                    pet.getGender(),
+                    StringUtils.hasText(pet.getPetProfileImg()) ? pet.getPetProfileImg() : "",
+                    StringUtils.hasText(pet.getFeed()) ? pet.getFeed() : "",
+                    pet.getCareCategories().stream().map(CareCategory::getId).toList()
             );
         }
     }

--- a/src/main/java/com/kcy/fitapet/domain/pet/dto/PetSaveReq.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/dto/PetSaveReq.java
@@ -10,13 +10,14 @@ import jakarta.validation.constraints.Past;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
 
 @Schema(description = "반려동물 등록 요청")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PetRegisterReq {
+public class PetSaveReq {
     @Schema(description = "반려동물 이름") @NotBlank(message = "반려동물 이름을 입력해주세요.")
     private String petName;
     @Schema(description = "반려동물 종류", example = "강아지") @NotBlank(message = "반려동물 종류를 입력해주세요.")
@@ -38,7 +39,7 @@ public class PetRegisterReq {
                 .gender(gender)
                 .neutered(neutralization)
                 .birthdate(birthdate)
-                .petProfileImg(profileImg)
+                .petProfileImg(StringUtils.hasText(profileImg) ? profileImg : null)
                 .build();
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/pet/exception/PetErrorCode.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/exception/PetErrorCode.java
@@ -8,10 +8,6 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum PetErrorCode implements StatusCode {
-    /* 400 BAD_REQUEST */
-    ALREADY_CARED(HttpStatus.BAD_REQUEST, "이미 케어한 날짜에 대한 요청"),
-    NOT_TODAY_CARE(HttpStatus.BAD_REQUEST, "오늘 날짜에 대한 요청이 아님"),
-
     /* 403 FORBIDDEN */
     NOT_MANAGER_PET(HttpStatus.FORBIDDEN, "관리자 자격이 없는 반려 동물에 대한 요청");
 

--- a/src/main/java/com/kcy/fitapet/domain/pet/exception/PetErrorCode.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/exception/PetErrorCode.java
@@ -8,6 +8,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum PetErrorCode implements StatusCode {
+    /* 400 BAD_REQUEST */
+    ALREADY_CARED(HttpStatus.BAD_REQUEST, "이미 케어한 날짜에 대한 요청"),
+    NOT_TODAY_CARE(HttpStatus.BAD_REQUEST, "오늘 날짜에 대한 요청이 아님"),
+
+    /* 403 FORBIDDEN */
     NOT_MANAGER_PET(HttpStatus.FORBIDDEN, "관리자 자격이 없는 반려 동물에 대한 요청");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/kcy/fitapet/domain/pet/service/component/PetManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/service/component/PetManageService.java
@@ -48,4 +48,11 @@ public class PetManageService {
 
         return careSearchService.checkCategoryExist(categoryName, petIds);
     }
+
+    @Transactional(readOnly = true)
+    public PetInfoRes getPets(Long userId) {
+        List<Manager> managers = memberSearchService.findAllManagerByMemberId(userId);
+        List<Pet> pets = managers.stream().map(Manager::getPet).toList();
+        return PetInfoRes.ofPetInfo(pets);
+    }
 }

--- a/src/main/java/com/kcy/fitapet/global/common/response/code/ErrorCode.java
+++ b/src/main/java/com/kcy/fitapet/global/common/response/code/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode implements StatusCode {
     NOT_FOUND_PET(NOT_FOUND, "존재하지 않는 반려동물입니다."),
     NOT_FOUND_PET_CARE(NOT_FOUND, "존재하지 않는 반려동물 돌봄입니다."),
     NOT_FOUND_PET_SCHEDULE(NOT_FOUND, "존재하지 않는 반려동물 일정입니다."),
+    NOT_FOUND_CARE_DATE(NOT_FOUND, "존재하지 않는 돌봄 날짜입니다."),
 
     /**
      * 500 INTERNAL_SERVER_ERROR: 서버에서 에러가 발생한 경우

--- a/src/main/java/com/kcy/fitapet/global/config/QueryDslConfig.java
+++ b/src/main/java/com/kcy/fitapet/global/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.kcy.fitapet.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 작업 이유
- Front-end Delegate를 위한 AT 유효성 검증 API 개설
- 빈 문자열 ↔ NULL 변환을 통해 DB record의 NULL 유지 및 클라이언트 측 요청&응답에 대해선 빈 문자열 처리
- 반려동물 리스트 조회 API
- 반려동물 케어 목록 조회 API
- Care 수행 API

## 작업 사항
### 1️⃣ Front-end Delegate를 위한 AT 유효성 검증 API 개설
- 요청: `GET /api/v1/auth/verify`
- 성공 시에는 Login 했을 때와 같은 응답을 반환합니다.
- 성공 이외의 모든 경우에는 `401 Error`를 반환합니다.
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/feb15277-ce59-44b8-b56b-4fd59815461d)


<br/>

### 2️⃣ 빈 문자열 ↔ NULL 변환
- 기존에 null 데이터를 반환하는 응답을 수정했습니다.
- 대신 빈 문자열의 데이터를 전송하는 경우엔 server에서 자동으로 NULL을 record에 삽입하도록 수정하였습니다.
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/56419d0b-fe2f-4698-8236-2953f57e210a)


<br/>

### 3️⃣ 반려동물 리스트 조회 API
> ⚠️ `careIds` 항목은 `deprecated`될 예정입니다. 사용하지 마세요.
- 요청: `GET /api/v2/users/{user_id}/pets`
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/7cc3d0de-27cf-4747-88dc-0ef004a61e9d)


<br/>

### 4️⃣ 반려동물 케어 목록 조회 API
- 요청: `GET /api/v2/users/{user_id}/pets/{pet_id}/cares`
- 응답은 `오늘 날짜`에 해당하는 `careDateId`를 보내드립니다.
- 따라서 응답에 대한 careDateId의 값을 통한 Care 수행 API는 언제나 성공합니다. 
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/587161cc-77ab-4436-b1bc-bbb1c8cd5d57)


<br/>

### 5️⃣ Care 수행 API
- 요청: `/api/v2/users/{user_id}/pets/{pet_id}/cares/{care_id}/care-dates/{care_cate_id}`
- 오늘 날짜에 해당하는 요청이 아니면 

**🟢 정상 응답**
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/cac2652d-d630-4d31-9a6c-b048a2f699b6)


**❌ 오늘 날짜가 아닌 케어에 대한 요청 거부**
- 오늘 날짜에 해당하는 `care_date_id`가 아닌 경우 거부
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/864f9d69-2094-4923-b970-d4dc269643a6)


**❌ 이미 수행한 Care에 대한 요청 거부**
- 한 번 수행한 care에 대해서는 취소가 아닌 요청 거부
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/86f9023a-6491-45aa-a2aa-9e8ab49784bb)


**❓ 추가 고려 사항**
1. care_id에 대해 유효한 care_date_id를 요청한 것인지 검증 로직 추가 예정
2. care 수행 허용 시간 예외 처리에 대해 회의 필요 (ex. 화요일 18시 일정은 화요일 17시 50분 이후에 정상 처리 가능)

<br/>

## 이슈 연결
close #75 #76 #77 