### PR TITLE
✨ 일정 등록 및 3가지 조회 API

### DIFF
--- a/.github/workflows/kakao_ci.yml
+++ b/.github/workflows/kakao_ci.yml
@@ -26,8 +26,6 @@ jobs:
 
             - name: Setup Chrome
               uses: browser-actions/setup-chrome@v1
-              run: |
-                ${{ steps.setup-chrome.outputs.chrome-path }} --version
 
             - name: Determine event type and trigger action at Windows
               if: runner.os == 'Windows'

--- a/src/main/java/com/kcy/fitapet/domain/care/dto/CareInfoRes.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/dto/CareInfoRes.java
@@ -1,5 +1,8 @@
 package com.kcy.fitapet.domain.care.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 import com.kcy.fitapet.domain.care.domain.CareCategory;
 import lombok.Getter;
 
@@ -7,6 +10,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Getter
@@ -25,6 +29,7 @@ public class CareInfoRes {
         List<CareDto> cares
     ) {
         public static CareCategoryDto of(Long id, String categoryName, List<CareDto> cares) {
+            cares.sort(Comparator.comparing(CareDto::careDate));
             return new CareCategoryDto(id, categoryName, cares);
         }
     }
@@ -33,11 +38,13 @@ public class CareInfoRes {
             Long careId,
             Long careDateId,
             String careName,
-            String careDate,
+            @JsonSerialize(using = LocalTimeSerializer.class)
+            @JsonFormat(pattern = "HH:mm:ss")
+            LocalTime careDate,
             boolean isClear
     ) {
         public static CareDto of(Long careId, Long careDateId, String careName, LocalTime careDate, boolean isClear) {
-            return new CareDto(careId, careDateId, careName, careDate.format(DateTimeFormatter.ofPattern("HH:mm:ss")), isClear);
+            return new CareDto(careId, careDateId, careName, careDate, isClear);
         }
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/care/dto/CareSaveReq.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/dto/CareSaveReq.java
@@ -1,22 +1,18 @@
 package com.kcy.fitapet.domain.care.dto;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 import com.kcy.fitapet.domain.care.domain.Care;
 import com.kcy.fitapet.domain.care.domain.CareCategory;
 import com.kcy.fitapet.domain.care.domain.CareDate;
-import com.kcy.fitapet.domain.care.exception.CareErrorCode;
 import com.kcy.fitapet.domain.care.type.WeekType;
-import com.kcy.fitapet.global.common.response.exception.GlobalErrorException;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalTime;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
 

--- a/src/main/java/com/kcy/fitapet/domain/log/dao/CareLogQueryRepositoryImpl.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/dao/CareLogQueryRepositoryImpl.java
@@ -17,13 +17,10 @@ import java.time.format.DateTimeFormatter;
 @Slf4j
 public class CareLogQueryRepositoryImpl implements CareLogQueryRepository {
     private final JPAQueryFactory queryFactory;
-    private QCareLog careLog = QCareLog.careLog;
+    private final QCareLog careLog = QCareLog.careLog;
 
     @Override
     public boolean existsByCareDateIdAndLogDate(Long careDateId, LocalDateTime logDate) {
-        log.info("start: {}", Expressions.asDateTime(logDate.withHour(0).withMinute(0).withSecond(0)));
-        log.info("end: {}", Expressions.asDateTime(logDate.withHour(23).withMinute(59).withSecond(59)));
-
         return queryFactory.selectFrom(careLog)
                 .where(careLog.careDate.id.eq(careDateId)
                         .and(careLog.logDate.between(

--- a/src/main/java/com/kcy/fitapet/domain/pet/dao/PetScheduleRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/dao/PetScheduleRepository.java
@@ -1,0 +1,7 @@
+package com.kcy.fitapet.domain.pet.dao;
+
+import com.kcy.fitapet.domain.pet.domain.PetSchedule;
+import com.kcy.fitapet.global.common.repository.ExtendedRepository;
+
+public interface PetScheduleRepository extends ExtendedRepository<PetSchedule, Long> {
+}

--- a/src/main/java/com/kcy/fitapet/domain/pet/domain/PetSchedule.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/domain/PetSchedule.java
@@ -6,12 +6,17 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "PET_SCHEDULE")
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @Getter
-public class PetSchedule extends DateAuditable {
+@EntityListeners(AuditingEntityListener.class)
+public class PetSchedule {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -22,6 +27,10 @@ public class PetSchedule extends DateAuditable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule_id")
     private Schedule schedule;
+
+    @CreatedDate
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
 
     public static PetSchedule of(Pet pet, Schedule schedule) {
         PetSchedule petSchedule = new PetSchedule();

--- a/src/main/java/com/kcy/fitapet/domain/pet/domain/PetSchedule.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/domain/PetSchedule.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "PET_SCHEDULE")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
 @Getter
 public class PetSchedule extends DateAuditable {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,7 +23,18 @@ public class PetSchedule extends DateAuditable {
     @JoinColumn(name = "schedule_id")
     private Schedule schedule;
 
-    public void updatePet(Pet pet) {
+    public static PetSchedule of(Pet pet, Schedule schedule) {
+        PetSchedule petSchedule = new PetSchedule();
+        petSchedule.mappingPetAndSchedule(pet, schedule);
+        return petSchedule;
+    }
+
+    public void mappingPetAndSchedule(Pet pet, Schedule schedule) {
+        updatePet(pet);
+        updateSchedule(schedule);
+    }
+
+    private void updatePet(Pet pet) {
         if (this.pet != null) {
             this.pet.getSchedules().remove(this);
         }
@@ -39,10 +50,5 @@ public class PetSchedule extends DateAuditable {
 
         this.schedule = schedule;
         schedule.getPets().add(this);
-    }
-
-    public void mappingPetAndSchedule(Pet pet, Schedule schedule) {
-        updatePet(pet);
-        updateSchedule(schedule);
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/pet/domain/PetSchedule.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/domain/PetSchedule.java
@@ -22,4 +22,27 @@ public class PetSchedule extends DateAuditable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule_id")
     private Schedule schedule;
+
+    public void updatePet(Pet pet) {
+        if (this.pet != null) {
+            this.pet.getSchedules().remove(this);
+        }
+
+        this.pet = pet;
+        pet.getSchedules().add(this);
+    }
+
+    public void updateSchedule(Schedule schedule) {
+        if (this.schedule != null) {
+            this.schedule.getPets().remove(this);
+        }
+
+        this.schedule = schedule;
+        schedule.getPets().add(this);
+    }
+
+    public void mappingPetAndSchedule(Pet pet, Schedule schedule) {
+        updatePet(pet);
+        updateSchedule(schedule);
+    }
 }

--- a/src/main/java/com/kcy/fitapet/domain/pet/service/module/PetSaveService.java
+++ b/src/main/java/com/kcy/fitapet/domain/pet/service/module/PetSaveService.java
@@ -1,18 +1,33 @@
 package com.kcy.fitapet.domain.pet.service.module;
 
 import com.kcy.fitapet.domain.pet.dao.PetRepository;
+import com.kcy.fitapet.domain.pet.dao.PetScheduleRepository;
 import com.kcy.fitapet.domain.pet.domain.Pet;
+import com.kcy.fitapet.domain.pet.domain.PetSchedule;
+import com.kcy.fitapet.domain.schedule.domain.Schedule;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PetSaveService {
     private final PetRepository petRepository;
+    private final PetScheduleRepository petScheduleRepository;
 
     @Transactional
     public Pet savePet(Pet pet) {;
         return petRepository.save(pet);
+    }
+
+    @Transactional
+    public void mappingAllPetAndSchedule(List<Pet> pets, Schedule schedule) {
+        List<PetSchedule> schedules = new ArrayList<>();
+        for (Pet pet : pets) {
+            schedules.add(PetSchedule.of(pet, schedule));
+        }
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
@@ -13,6 +13,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Tag(name = "스케줄 API", description = "반려동물 일정 관리 API")
 @Slf4j
@@ -24,7 +25,7 @@ public class ScheduleApi {
 
     @Operation(summary = "스케줄 등록")
     @PostMapping("/pets/{pet_id}/schedules")
-    @PreAuthorize("isAuthenticated() and #userId == principal.id and managerAuthorize.isManager(#userId, #petId)")
+    @PreAuthorize("isAuthenticated() and #userId == principal.userId and @managerAuthorize.isManager(#userId, #petId)")
     public ResponseEntity<?> saveSchedule(
             @PathVariable("user_id") Long userId,
             @PathVariable("pet_id") Long petId,
@@ -36,7 +37,7 @@ public class ScheduleApi {
 
     @Operation(summary = "pet_id에 속하는 반려동물 스케줄 조회", description = "count가 null이면 전체 조회, null이 아니면 현재 날짜&시간 이후 count 만큼 조회")
     @GetMapping("/pets/{pet_id}/schedules")
-    @PreAuthorize("isAuthenticated() and #userId == principal.id and managerAuthorize.isManager(#userId, #petId)")
+    @PreAuthorize("isAuthenticated() and #userId == principal.userId and @managerAuthorize.isManager(#userId, #petId)")
     public ResponseEntity<?> getPetSchedules(
             @PathVariable("user_id") Long userId,
             @PathVariable("pet_id") Long petId,
@@ -47,14 +48,14 @@ public class ScheduleApi {
 
     @Operation(summary = "관리 중인 반려동물 날짜별 스케줄 전체 조회")
     @GetMapping("/schedules")
-    @PreAuthorize("isAuthenticated() and #userId == principal.id")
+    @PreAuthorize("isAuthenticated() and #userId == principal.userId")
     public ResponseEntity<?> getCalendarSchedules(
             @PathVariable("user_id") Long userId,
             @RequestParam(value = "year") Integer year,
             @RequestParam(value = "month") Integer month,
             @RequestParam(value = "day") Integer day
     ) {
-        LocalDate date = LocalDate.of(year, month, day);
+        LocalDateTime date = LocalDate.of(year, month, day).atStartOfDay();
         return ResponseEntity.ok(SuccessResponse.from(scheduleManageService.findCalendarSchedules(userId, date)));
     }
 

--- a/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
@@ -1,0 +1,32 @@
+package com.kcy.fitapet.domain.schedule.api;
+
+import com.kcy.fitapet.domain.schedule.dto.ScheduleSaveDto;
+import com.kcy.fitapet.domain.schedule.service.component.ScheduleManageService;
+import com.kcy.fitapet.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/users/{user_id}/pets/{pet_id}/schedules")
+public class ScheduleApi {
+    private final ScheduleManageService scheduleManageService;
+
+    @Operation(summary = "스케줄 등록")
+    @PostMapping("")
+    @PreAuthorize("isAuthenticated() and #userId == principal.id and managerAuthorize.isManager(#userId, #petId)")
+    public ResponseEntity<?> saveSchedule(
+            @PathVariable("user_id") Long userId,
+            @PathVariable("pet_id") Long petId,
+            @RequestBody @Valid ScheduleSaveDto.Request request
+    ) {
+        scheduleManageService.saveSchedule(petId, request);
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
+}

--- a/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
@@ -34,7 +34,7 @@ public class ScheduleApi {
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 
-    @Operation(summary = "pet_id에 속하는 반려동물 스케줄 조회")
+    @Operation(summary = "pet_id에 속하는 반려동물 스케줄 조회", description = "count가 null이면 전체 조회, null이 아니면 현재 날짜&시간 이후 count 만큼 조회")
     @GetMapping("/pets/{pet_id}/schedules")
     @PreAuthorize("isAuthenticated() and #userId == principal.id and managerAuthorize.isManager(#userId, #petId)")
     public ResponseEntity<?> getPetSchedules(

--- a/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
@@ -43,7 +43,7 @@ public class ScheduleApi {
             @PathVariable("pet_id") Long petId,
             @RequestParam(value = "count", required = false) Integer count
     ) {
-        return ResponseEntity.ok(SuccessResponse.from(scheduleManageService.findPetSchedules(petId, count)));
+        return ResponseEntity.ok(SuccessResponse.from("schedules", scheduleManageService.findPetSchedules(petId, count).getSchedules()));
     }
 
     @Operation(summary = "관리 중인 반려동물 날짜별 스케줄 전체 조회")
@@ -57,8 +57,6 @@ public class ScheduleApi {
     ) {
         LocalDateTime date = LocalDate.of(year, month, day).atStartOfDay();
         log.info("date: {}", date);
-        return ResponseEntity.ok(SuccessResponse.from(scheduleManageService.findPetSchedules(userId, date)));
+        return ResponseEntity.ok(SuccessResponse.from("schedules", scheduleManageService.findPetSchedules(userId, date).getSchedules()));
     }
-
-
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
@@ -4,6 +4,7 @@ import com.kcy.fitapet.domain.schedule.dto.ScheduleSaveDto;
 import com.kcy.fitapet.domain.schedule.service.component.ScheduleManageService;
 import com.kcy.fitapet.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,15 +12,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+
+@Tag(name = "스케줄 API", description = "반려동물 일정 관리 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v2/users/{user_id}/pets/{pet_id}/schedules")
+@RequestMapping("/api/v2/users/{user_id}")
 public class ScheduleApi {
     private final ScheduleManageService scheduleManageService;
 
     @Operation(summary = "스케줄 등록")
-    @PostMapping("")
+    @PostMapping("/pets/{pet_id}/schedules")
     @PreAuthorize("isAuthenticated() and #userId == principal.id and managerAuthorize.isManager(#userId, #petId)")
     public ResponseEntity<?> saveSchedule(
             @PathVariable("user_id") Long userId,
@@ -29,4 +33,30 @@ public class ScheduleApi {
         scheduleManageService.saveSchedule(petId, request);
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
+
+    @Operation(summary = "pet_id에 속하는 반려동물 스케줄 조회")
+    @GetMapping("/pets/{pet_id}/schedules")
+    @PreAuthorize("isAuthenticated() and #userId == principal.id and managerAuthorize.isManager(#userId, #petId)")
+    public ResponseEntity<?> getPetSchedules(
+            @PathVariable("user_id") Long userId,
+            @PathVariable("pet_id") Long petId,
+            @RequestParam(value = "count", required = false) Integer count
+    ) {
+        return ResponseEntity.ok(SuccessResponse.from(scheduleManageService.findPetSchedules(petId, count)));
+    }
+
+    @Operation(summary = "관리 중인 반려동물 날짜별 스케줄 전체 조회")
+    @GetMapping("/schedules")
+    @PreAuthorize("isAuthenticated() and #userId == principal.id")
+    public ResponseEntity<?> getCalendarSchedules(
+            @PathVariable("user_id") Long userId,
+            @RequestParam(value = "year") Integer year,
+            @RequestParam(value = "month") Integer month,
+            @RequestParam(value = "day") Integer day
+    ) {
+        LocalDate date = LocalDate.of(year, month, day);
+        return ResponseEntity.ok(SuccessResponse.from(scheduleManageService.findCalendarSchedules(userId, date)));
+    }
+
+
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
@@ -56,6 +56,7 @@ public class ScheduleApi {
             @RequestParam(value = "day") Integer day
     ) {
         LocalDateTime date = LocalDate.of(year, month, day).atStartOfDay();
+        log.info("date: {}", date);
         return ResponseEntity.ok(SuccessResponse.from(scheduleManageService.findPetSchedules(userId, date)));
     }
 

--- a/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/api/ScheduleApi.java
@@ -56,7 +56,7 @@ public class ScheduleApi {
             @RequestParam(value = "day") Integer day
     ) {
         LocalDateTime date = LocalDate.of(year, month, day).atStartOfDay();
-        return ResponseEntity.ok(SuccessResponse.from(scheduleManageService.findCalendarSchedules(userId, date)));
+        return ResponseEntity.ok(SuccessResponse.from(scheduleManageService.findPetSchedules(userId, date)));
     }
 
 

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 public interface ScheduleQueryRepository {
     List<Schedule> findTopCountScheduleByIdOnDate(Long id, LocalDateTime scheduleDate, Integer count);
 
-    List<ScheduleInfoDto.ScheduleQueryDslRes> findSchedulesByCalender(LocalDateTime date, List<Long> petIds);
+    List<ScheduleInfoDto.ScheduleInfo> findSchedulesByCalender(LocalDateTime date, List<Long> petIds);
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepository.java
@@ -7,7 +7,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ScheduleQueryRepository {
-    List<Schedule> findTopCountScheduleByIdOnDate(Long id, LocalDateTime scheduleDate, Integer count);
+    List<Schedule> findScheduleByPetIdOnDate(Long petId, LocalDateTime date);
+    List<Schedule> findTopCountSchedulesByIdOnDate(Long id, LocalDateTime scheduleDate, Integer count);
 
     List<ScheduleInfoDto.ScheduleInfo> findSchedulesByCalender(LocalDateTime date, List<Long> petIds);
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepository.java
@@ -1,0 +1,10 @@
+package com.kcy.fitapet.domain.schedule.dao;
+
+import com.kcy.fitapet.domain.schedule.domain.Schedule;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ScheduleQueryRepository {
+    List<Schedule> findTopCountScheduleByIdOnDate(Long id, LocalDateTime scheduleDate, Integer count);
+}

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 public interface ScheduleQueryRepository {
     List<Schedule> findTopCountScheduleByIdOnDate(Long id, LocalDateTime scheduleDate, Integer count);
 
-    List<ScheduleInfoDto.ScheduleInfo> findSchedulesByCalender(Long userId, LocalDateTime date, List<Long> petIds);
+    List<ScheduleInfoDto.ScheduleQueryDslRes> findSchedulesByCalender(LocalDateTime date, List<Long> petIds);
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepository.java
@@ -1,10 +1,13 @@
 package com.kcy.fitapet.domain.schedule.dao;
 
 import com.kcy.fitapet.domain.schedule.domain.Schedule;
+import com.kcy.fitapet.domain.schedule.dto.ScheduleInfoDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ScheduleQueryRepository {
     List<Schedule> findTopCountScheduleByIdOnDate(Long id, LocalDateTime scheduleDate, Integer count);
+
+    List<ScheduleInfoDto.ScheduleInfo> findSchedulesByCalender(Long userId, LocalDateTime date, List<Long> petIds);
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepositoryImpl.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.kcy.fitapet.domain.schedule.dao;
+
+import com.kcy.fitapet.domain.schedule.domain.QSchedule;
+import com.kcy.fitapet.domain.schedule.domain.Schedule;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ScheduleQueryRepositoryImpl implements ScheduleQueryRepository {
+    private final JPAQueryFactory queryFactory;
+    private final QSchedule schedule = QSchedule.schedule;
+
+    @Override
+    public List<Schedule> findTopCountScheduleByIdOnDate(Long id, LocalDateTime scheduleDate, Integer count) {
+        return queryFactory.selectFrom(schedule)
+                .where(schedule.id.eq(id)
+                        .and(schedule.reservationDt.between(
+                                Expressions.asDateTime(scheduleDate.withHour(0).withMinute(0).withSecond(0)),
+                                Expressions.asDateTime(scheduleDate.withHour(23).withMinute(59).withSecond(59))
+                        )))
+                .orderBy(schedule.reservationDt.asc())
+                .limit(count)
+                .fetch();
+    }
+}

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepositoryImpl.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepositoryImpl.java
@@ -39,8 +39,9 @@ public class ScheduleQueryRepositoryImpl implements ScheduleQueryRepository {
     }
 
     @Override
-    public List<ScheduleInfoDto.ScheduleInfo> findSchedulesByCalender(Long userId, LocalDateTime date, List<Long> petIds) {
+    public List<ScheduleInfoDto.ScheduleQueryDslRes> findSchedulesByCalender(LocalDateTime date, List<Long> petIds) {
         return queryFactory
+                .select(schedule.id, schedule.scheduleName, schedule.location, schedule.reservationDt, petSchedule.pet.id)
                 .from(schedule)
                 .leftJoin(petSchedule).on(schedule.id.eq(petSchedule.schedule.id))
                 .where(
@@ -50,21 +51,25 @@ public class ScheduleQueryRepositoryImpl implements ScheduleQueryRepository {
                                         Expressions.asDateTime(date.withHour(23).withMinute(59).withSecond(59))
                                 ))
                 )
+                .orderBy(schedule.reservationDt.asc())
                 .transform(
                     groupBy(schedule.id).list(
                         Projections.constructor(
-                            ScheduleInfoDto.ScheduleInfo.class,
+                            ScheduleInfoDto.ScheduleQueryDslRes.class,
                             schedule.id,
                             schedule.scheduleName,
                             schedule.location,
                             schedule.reservationDt,
+//                            list(
+//                                    Projections.constructor(
+//                                            ScheduleInfoDto.ParticipantPetInfo.class,
+//                                            petSchedule.pet.id,
+//                                            petSchedule.pet.petProfileImg
+//                                    )
+//                            )
                             list(
-                                Projections.constructor(
-                                    ScheduleInfoDto.ParticipantPetInfo.class,
-                                    petSchedule.pet.id,
-                                    petSchedule.pet.petProfileImg
-                                )
-                            ).as("pets")
+                                petSchedule.pet.id
+                            )
                         )
                     )
                 );

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepositoryImpl.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleQueryRepositoryImpl.java
@@ -1,7 +1,11 @@
 package com.kcy.fitapet.domain.schedule.dao;
 
+import com.kcy.fitapet.domain.pet.domain.QPetSchedule;
 import com.kcy.fitapet.domain.schedule.domain.QSchedule;
 import com.kcy.fitapet.domain.schedule.domain.Schedule;
+import com.kcy.fitapet.domain.schedule.dto.ScheduleInfoDto;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -11,11 +15,15 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+
 @Repository
 @RequiredArgsConstructor
 public class ScheduleQueryRepositoryImpl implements ScheduleQueryRepository {
     private final JPAQueryFactory queryFactory;
     private final QSchedule schedule = QSchedule.schedule;
+    private final QPetSchedule petSchedule = QPetSchedule.petSchedule;
 
     @Override
     public List<Schedule> findTopCountScheduleByIdOnDate(Long id, LocalDateTime scheduleDate, Integer count) {
@@ -28,5 +36,37 @@ public class ScheduleQueryRepositoryImpl implements ScheduleQueryRepository {
                 .orderBy(schedule.reservationDt.asc())
                 .limit(count)
                 .fetch();
+    }
+
+    @Override
+    public List<ScheduleInfoDto.ScheduleInfo> findSchedulesByCalender(Long userId, LocalDateTime date, List<Long> petIds) {
+        return queryFactory
+                .from(schedule)
+                .leftJoin(petSchedule).on(schedule.id.eq(petSchedule.schedule.id))
+                .where(
+                        petSchedule.pet.id.in(petIds)
+                                .and(schedule.reservationDt.between(
+                                        Expressions.asDateTime(date.withHour(0).withMinute(0).withSecond(0)),
+                                        Expressions.asDateTime(date.withHour(23).withMinute(59).withSecond(59))
+                                ))
+                )
+                .transform(
+                    groupBy(schedule.id).list(
+                        Projections.constructor(
+                            ScheduleInfoDto.ScheduleInfo.class,
+                            schedule.id,
+                            schedule.scheduleName,
+                            schedule.location,
+                            schedule.reservationDt,
+                            list(
+                                Projections.constructor(
+                                    ScheduleInfoDto.ParticipantPetInfo.class,
+                                    petSchedule.pet.id,
+                                    petSchedule.pet.petProfileImg
+                                )
+                            ).as("pets")
+                        )
+                    )
+                );
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleRepository.java
@@ -1,0 +1,7 @@
+package com.kcy.fitapet.domain.schedule.dao;
+
+import com.kcy.fitapet.domain.schedule.domain.Schedule;
+import com.kcy.fitapet.global.common.repository.ExtendedRepository;
+
+public interface ScheduleRepository extends ExtendedRepository<Schedule, Long> {
+}

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dao/ScheduleRepository.java
@@ -3,5 +3,8 @@ package com.kcy.fitapet.domain.schedule.dao;
 import com.kcy.fitapet.domain.schedule.domain.Schedule;
 import com.kcy.fitapet.global.common.repository.ExtendedRepository;
 
+import java.util.List;
+
 public interface ScheduleRepository extends ExtendedRepository<Schedule, Long> {
+    public List<Schedule> findAllById(Long id);
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/domain/Schedule.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/domain/Schedule.java
@@ -17,8 +17,7 @@ import java.util.List;
 @Getter
 @Table(name = "SCHEDULE")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@DynamicInsert
-@ToString(of = {"scheduleName", "location", "reservationDt", "notifyDt", "isDone"})
+@ToString(of = {"scheduleName", "location", "reservationDt", "notifyDt"})
 public class Schedule extends AuthorAuditable {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -34,9 +33,6 @@ public class Schedule extends AuthorAuditable {
     @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "notify_dt")
     private LocalDateTime notifyDt;
-
-    @Column(name = "is_done") @ColumnDefault("false")
-    private boolean isDone = false;
 
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL)
     private List<PetSchedule> pets = new ArrayList<>();
@@ -56,9 +52,5 @@ public class Schedule extends AuthorAuditable {
                 .reservationDt(reservationDt)
                 .notifyDt(notifyDt)
                 .build();
-    }
-
-    public void updateState() {
-        this.isDone = !this.isDone;
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/domain/Schedule.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/domain/Schedule.java
@@ -5,19 +5,19 @@ import com.kcy.fitapet.domain.model.AuthorAuditable;
 import com.kcy.fitapet.domain.model.DateAuditable;
 import com.kcy.fitapet.domain.pet.domain.PetSchedule;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 @Table(name = "SCHEDULE")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert
 @ToString(of = {"scheduleName", "location", "reservationDt", "notifyDt", "isDone"})
 public class Schedule extends AuthorAuditable {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,27 +36,29 @@ public class Schedule extends AuthorAuditable {
     private LocalDateTime notifyDt;
 
     @Column(name = "is_done") @ColumnDefault("false")
-    private boolean isDone;
+    private boolean isDone = false;
 
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL)
     private List<PetSchedule> pets = new ArrayList<>();
 
     @Builder
-    private Schedule(String scheduleName, String location, LocalDateTime reservationDt, LocalDateTime notifyDt, boolean isDone) {
+    private Schedule(String scheduleName, String location, LocalDateTime reservationDt, LocalDateTime notifyDt) {
         this.scheduleName = scheduleName;
         this.location = location;
         this.reservationDt = reservationDt;
         this.notifyDt = notifyDt;
-        this.isDone = isDone;
     }
 
-    public static Schedule of(String scheduleName, String location, LocalDateTime reservationDt, LocalDateTime notifyDt, boolean isDone) {
+    public static Schedule of(String scheduleName, String location, LocalDateTime reservationDt, LocalDateTime notifyDt) {
         return Schedule.builder()
                 .scheduleName(scheduleName)
                 .location(location)
                 .reservationDt(reservationDt)
                 .notifyDt(notifyDt)
-                .isDone(isDone)
                 .build();
+    }
+
+    public void updateState() {
+        this.isDone = !this.isDone;
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dto/ScheduleInfoDto.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dto/ScheduleInfoDto.java
@@ -8,9 +8,11 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.kcy.fitapet.domain.pet.domain.Pet;
 import com.kcy.fitapet.domain.schedule.domain.Schedule;
 import lombok.Getter;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 public class ScheduleInfoDto {
@@ -89,6 +91,11 @@ public class ScheduleInfoDto {
             Long petId,
             String petProfileImage
     ) {
+        public ParticipantPetInfo(Long petId, String petProfileImage) {
+            this.petId = petId;
+            this.petProfileImage = Objects.toString(petProfileImage, "");
+        }
+
         public static ParticipantPetInfo from(Pet pet) {
             return new ParticipantPetInfo(
                     pet.getId(),
@@ -96,6 +103,4 @@ public class ScheduleInfoDto {
             );
         }
     }
-
-
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dto/ScheduleInfoDto.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dto/ScheduleInfoDto.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.kcy.fitapet.domain.pet.domain.Pet;
 import com.kcy.fitapet.domain.schedule.domain.Schedule;
 import lombok.Getter;
@@ -26,15 +26,14 @@ public class ScheduleInfoDto {
             Long scheduleId,
             String scheduleName,
             String location,
-            @JsonSerialize(using = LocalTimeSerializer.class)
-            @JsonFormat(pattern = "HH:mm:ss")
+            @JsonSerialize(using = LocalDateTimeSerializer.class)
+            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             @JsonProperty("reservationDate")
-            LocalDateTime reservationDate,
+            LocalDateTime reservationDt,
             @JsonInclude(JsonInclude.Include.NON_EMPTY)
             List<ParticipantPetInfo> pets
     ) {
         public static ScheduleInfo from(Schedule schedule, List<Pet> pets) {
-
             return new ScheduleInfo(
                     schedule.getId(),
                     schedule.getScheduleName(),
@@ -45,8 +44,47 @@ public class ScheduleInfoDto {
                             .toList()
             );
         }
+
+        public static ScheduleInfo valueOf(ScheduleQueryDslRes queryDslRes, List<Pet> pets) {
+            return new ScheduleInfo(
+                    queryDslRes.scheduleId(),
+                    queryDslRes.scheduleName(),
+                    queryDslRes.location(),
+                    queryDslRes.reservationDt(),
+                    queryDslRes.petIds().stream()
+                            .map(petId -> pets.stream()
+                                    .filter(pet -> pet.getId().equals(petId))
+                                    .findFirst()
+                                    .map(ParticipantPetInfo::from)
+                                    .orElseThrow(() -> new IllegalArgumentException("해당 반려동물이 존재하지 않습니다.")))
+                            .toList()
+            );
+        }
     }
 
+    /**
+     * QueryDsl로 조회한 스케줄 정보 <br/>
+     * Query 최적화를 위한 목적의 DTO이며, 클라이언트 응답에는 ScheduleInfo로 변경하여 응답한다.
+     * @param scheduleId
+     * @param scheduleName
+     * @param location
+     * @param reservationDt
+     * @param petIds
+     */
+    public record ScheduleQueryDslRes(
+            Long scheduleId,
+            String scheduleName,
+            String location,
+            LocalDateTime reservationDt,
+            List<Long> petIds
+    ) {
+    }
+
+    /**
+     * 스케줄 참여 반려동물 정보
+     * @param petId
+     * @param petProfileImage
+     */
     public record ParticipantPetInfo(
             Long petId,
             String petProfileImage
@@ -58,4 +96,6 @@ public class ScheduleInfoDto {
             );
         }
     }
+
+
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dto/ScheduleInfoDto.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dto/ScheduleInfoDto.java
@@ -1,0 +1,59 @@
+package com.kcy.fitapet.domain.schedule.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import com.kcy.fitapet.domain.pet.domain.Pet;
+import com.kcy.fitapet.domain.schedule.domain.Schedule;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class ScheduleInfoDto {
+    private List<?> schedules;
+
+    public static ScheduleInfoDto of(List<ScheduleInfo> schedules) {
+        ScheduleInfoDto scheduleInfoDto = new ScheduleInfoDto();
+        scheduleInfoDto.schedules = schedules;
+        return scheduleInfoDto;
+    }
+
+    public record ScheduleInfo(
+            Long scheduleId,
+            String scheduleName,
+            String location,
+            @JsonSerialize(using = LocalTimeSerializer.class)
+            @JsonFormat(pattern = "HH:mm:ss")
+            LocalDateTime reservationDate,
+            @JsonInclude(JsonInclude.Include.NON_EMPTY)
+            List<ParticipantPetInfo> pets
+    ) {
+        public static ScheduleInfo from(Schedule schedule, List<Pet> pets) {
+
+            return new ScheduleInfo(
+                    schedule.getId(),
+                    schedule.getScheduleName(),
+                    schedule.getLocation(),
+                    schedule.getReservationDt(),
+                    pets.stream()
+                            .map(ParticipantPetInfo::from)
+                            .toList()
+            );
+        }
+    }
+
+    private record ParticipantPetInfo(
+            Long petId,
+            String petProfileImage
+    ) {
+        public static ParticipantPetInfo from(Pet pet) {
+            return new ParticipantPetInfo(
+                    pet.getId(),
+                    pet.getPetProfileImg()
+            );
+        }
+    }
+}

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dto/ScheduleInfoDto.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dto/ScheduleInfoDto.java
@@ -2,6 +2,7 @@ package com.kcy.fitapet.domain.schedule.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 import com.kcy.fitapet.domain.pet.domain.Pet;
@@ -27,6 +28,7 @@ public class ScheduleInfoDto {
             String location,
             @JsonSerialize(using = LocalTimeSerializer.class)
             @JsonFormat(pattern = "HH:mm:ss")
+            @JsonProperty("reservationDate")
             LocalDateTime reservationDate,
             @JsonInclude(JsonInclude.Include.NON_EMPTY)
             List<ParticipantPetInfo> pets
@@ -45,7 +47,7 @@ public class ScheduleInfoDto {
         }
     }
 
-    private record ParticipantPetInfo(
+    public record ParticipantPetInfo(
             Long petId,
             String petProfileImage
     ) {

--- a/src/main/java/com/kcy/fitapet/domain/schedule/dto/ScheduleSaveDto.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/dto/ScheduleSaveDto.java
@@ -1,0 +1,39 @@
+package com.kcy.fitapet.domain.schedule.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import com.kcy.fitapet.domain.schedule.domain.Schedule;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ScheduleSaveDto {
+    @Schema(description = "스케줄 등록 요청")
+    public record Request(
+            @Schema(description = "스케줄 이름", example = "하루 병원 정기 검진", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotEmpty(message = "스케줄 이름은 필수입니다.")
+            String scheduleName,
+            @Schema(description = "장소", example = "oo 병원", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotNull
+            String location,
+            @Schema(description = "예약 날짜", example = "2021-10-10 10:10:10", requiredMode = Schema.RequiredMode.REQUIRED)
+            @JsonSerialize(using = LocalTimeSerializer.class)
+            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+            @NotNull(message = "예약 날짜는 필수입니다.")
+            LocalDateTime reservationDate,
+            @Schema(description = "알림 시간(분 단위)", example = "30 (단, 없으면 0)", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotNull
+            Integer notifyTime,
+            @Schema(description = "케어 동물 추가", example = "[1, 2, 3] (단, 없으면 빈 배열)", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotNull
+            List<Long> petIds
+    ) {
+        public Schedule toEntity() {
+            return Schedule.of(scheduleName, location, reservationDate, reservationDate.plusMinutes(notifyTime));
+        }
+    }
+}

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
@@ -1,5 +1,7 @@
 package com.kcy.fitapet.domain.schedule.service.component;
 
+import com.kcy.fitapet.domain.member.domain.Manager;
+import com.kcy.fitapet.domain.member.service.module.MemberSearchService;
 import com.kcy.fitapet.domain.pet.domain.Pet;
 import com.kcy.fitapet.domain.pet.service.module.PetSaveService;
 import com.kcy.fitapet.domain.pet.service.module.PetSearchService;
@@ -21,6 +23,8 @@ import java.util.List;
 @Slf4j
 @RequiredArgsConstructor
 public class ScheduleManageService {
+    private final MemberSearchService memberSearchService;
+
     private final ScheduleSearchService scheduleSearchService;
     private final ScheduleSaveService scheduleSaveService;
     private final PetSearchService petSearchService;
@@ -49,5 +53,16 @@ public class ScheduleManageService {
         List<ScheduleInfoDto.ScheduleInfo> scheduleInfo = schedules.stream()
                 .map(schedule -> ScheduleInfoDto.ScheduleInfo.from(schedule, new ArrayList<>())).toList();
         return ScheduleInfoDto.of(scheduleInfo);
+    }
+
+    @Transactional(readOnly = true)
+    public ScheduleInfoDto findCalendarSchedules(Long userId, LocalDateTime date) {
+        // 1. user가 관리하는 반려동물 목록 조회
+        List<Manager> managers = memberSearchService.findAllManagerByMemberId(userId);
+        List<Pet> pets = managers.stream().map(Manager::getPet).toList();
+
+        // 2. 반려동물 목록에 해당하는 스케줄 조회
+
+        return null;
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
@@ -63,10 +63,6 @@ public class ScheduleManageService {
         List<Long> petIds = pets.stream().map(Pet::getId).toList();
 
         // 2. 반려동물 목록에 해당하는 스케줄 조회
-//        List<ScheduleInfoDto.ScheduleQueryDslRes> queryDslRes = scheduleSearchService.findSchedulesByCalender(date, petIds);
-//        List<ScheduleInfoDto.ScheduleInfo> scheduleInfo = queryDslRes.stream()
-//                .map(schedule -> ScheduleInfoDto.ScheduleInfo.valueOf(schedule, pets)).toList();
-//        return ScheduleInfoDto.of(scheduleInfo);
         List<ScheduleInfoDto.ScheduleInfo> scheduleInfo = scheduleSearchService.findSchedulesByCalender(date, petIds);
         return ScheduleInfoDto.of(scheduleInfo);
     }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
@@ -1,0 +1,30 @@
+package com.kcy.fitapet.domain.schedule.service.component;
+
+import com.kcy.fitapet.domain.schedule.domain.Schedule;
+import com.kcy.fitapet.domain.schedule.dto.ScheduleSaveDto;
+import com.kcy.fitapet.domain.schedule.service.module.ScheduleSaveService;
+import com.kcy.fitapet.domain.schedule.service.module.ScheduleSearchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ScheduleManageService {
+    private final ScheduleSearchService scheduleSearchService;
+    private final ScheduleSaveService scheduleSaveService;
+    private final PetScheduleSaveService petScheduleSaveService;
+
+    public void saveSchedule(Long petId, ScheduleSaveDto.Request request) {
+        Schedule schedule = scheduleSaveService.saveSchedule(request.toEntity());
+
+        List<Long> petIds = request.petIds();
+        if (!petIds.contains(petId))
+            petIds.add(petId);
+
+        petScheduleSaveService.mappingAllPetAndSchedule(petIds, schedule);
+    }
+}

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
@@ -4,6 +4,7 @@ import com.kcy.fitapet.domain.pet.domain.Pet;
 import com.kcy.fitapet.domain.pet.service.module.PetSaveService;
 import com.kcy.fitapet.domain.pet.service.module.PetSearchService;
 import com.kcy.fitapet.domain.schedule.domain.Schedule;
+import com.kcy.fitapet.domain.schedule.dto.ScheduleInfoDto;
 import com.kcy.fitapet.domain.schedule.dto.ScheduleSaveDto;
 import com.kcy.fitapet.domain.schedule.service.module.ScheduleSaveService;
 import com.kcy.fitapet.domain.schedule.service.module.ScheduleSearchService;
@@ -12,6 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -35,6 +38,16 @@ public class ScheduleManageService {
         petSaveService.mappingAllPetAndSchedule(pets, schedule);
     }
 
-//    @Transactional
-//    public void
+    @Transactional(readOnly = true)
+    public ScheduleInfoDto findPetSchedules(Long petId, Integer count) {
+        LocalDateTime now = LocalDateTime.now();
+
+        List<Schedule> schedules = (count != null)
+                ? scheduleSearchService.findSchedules(petId, now, count)
+                : scheduleSearchService.findSchedules(petId);
+
+        List<ScheduleInfoDto.ScheduleInfo> scheduleInfo = schedules.stream()
+                .map(schedule -> ScheduleInfoDto.ScheduleInfo.from(schedule, new ArrayList<>())).toList();
+        return ScheduleInfoDto.of(scheduleInfo);
+    }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
@@ -56,13 +56,14 @@ public class ScheduleManageService {
     }
 
     @Transactional(readOnly = true)
-    public ScheduleInfoDto findCalendarSchedules(Long userId, LocalDateTime date) {
+    public ScheduleInfoDto findPetSchedules(Long userId, LocalDateTime date) {
         // 1. user가 관리하는 반려동물 목록 조회
-        List<Manager> managers = memberSearchService.findAllManagerByMemberId(userId);
-        List<Pet> pets = managers.stream().map(Manager::getPet).toList();
+        List<Pet> pets = memberSearchService.findAllManagerByMemberId(userId)
+                .stream().map(Manager::getPet).toList();
+        List<Long> petIds = pets.stream().map(Pet::getId).toList();
 
         // 2. 반려동물 목록에 해당하는 스케줄 조회
-
-        return null;
+        List<ScheduleInfoDto.ScheduleInfo> scheduleInfo = scheduleSearchService.findSchedulesByCalender(userId, date, petIds);
+        return ScheduleInfoDto.of(scheduleInfo);
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
@@ -1,5 +1,8 @@
 package com.kcy.fitapet.domain.schedule.service.component;
 
+import com.kcy.fitapet.domain.pet.domain.Pet;
+import com.kcy.fitapet.domain.pet.service.module.PetSaveService;
+import com.kcy.fitapet.domain.pet.service.module.PetSearchService;
 import com.kcy.fitapet.domain.schedule.domain.Schedule;
 import com.kcy.fitapet.domain.schedule.dto.ScheduleSaveDto;
 import com.kcy.fitapet.domain.schedule.service.module.ScheduleSaveService;
@@ -16,7 +19,8 @@ import java.util.List;
 public class ScheduleManageService {
     private final ScheduleSearchService scheduleSearchService;
     private final ScheduleSaveService scheduleSaveService;
-    private final PetScheduleSaveService petScheduleSaveService;
+    private final PetSearchService petSearchService;
+    private final PetSaveService petSaveService;
 
     public void saveSchedule(Long petId, ScheduleSaveDto.Request request) {
         Schedule schedule = scheduleSaveService.saveSchedule(request.toEntity());
@@ -25,6 +29,7 @@ public class ScheduleManageService {
         if (!petIds.contains(petId))
             petIds.add(petId);
 
-        petScheduleSaveService.mappingAllPetAndSchedule(petIds, schedule);
+        List<Pet> pets = petSearchService.findPetsByIds(petIds);
+        petSaveService.mappingAllPetAndSchedule(pets, schedule);
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
@@ -10,6 +10,7 @@ import com.kcy.fitapet.domain.schedule.service.module.ScheduleSearchService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -22,6 +23,7 @@ public class ScheduleManageService {
     private final PetSearchService petSearchService;
     private final PetSaveService petSaveService;
 
+    @Transactional
     public void saveSchedule(Long petId, ScheduleSaveDto.Request request) {
         Schedule schedule = scheduleSaveService.saveSchedule(request.toEntity());
 
@@ -32,4 +34,7 @@ public class ScheduleManageService {
         List<Pet> pets = petSearchService.findPetsByIds(petIds);
         petSaveService.mappingAllPetAndSchedule(pets, schedule);
     }
+
+//    @Transactional
+//    public void
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
@@ -63,7 +63,11 @@ public class ScheduleManageService {
         List<Long> petIds = pets.stream().map(Pet::getId).toList();
 
         // 2. 반려동물 목록에 해당하는 스케줄 조회
-        List<ScheduleInfoDto.ScheduleInfo> scheduleInfo = scheduleSearchService.findSchedulesByCalender(userId, date, petIds);
+//        List<ScheduleInfoDto.ScheduleQueryDslRes> queryDslRes = scheduleSearchService.findSchedulesByCalender(date, petIds);
+//        List<ScheduleInfoDto.ScheduleInfo> scheduleInfo = queryDslRes.stream()
+//                .map(schedule -> ScheduleInfoDto.ScheduleInfo.valueOf(schedule, pets)).toList();
+//        return ScheduleInfoDto.of(scheduleInfo);
+        List<ScheduleInfoDto.ScheduleInfo> scheduleInfo = scheduleSearchService.findSchedulesByCalender(date, petIds);
         return ScheduleInfoDto.of(scheduleInfo);
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/component/ScheduleManageService.java
@@ -47,8 +47,8 @@ public class ScheduleManageService {
         LocalDateTime now = LocalDateTime.now();
 
         List<Schedule> schedules = (count != null)
-                ? scheduleSearchService.findSchedules(petId, now, count)
-                : scheduleSearchService.findSchedules(petId);
+                ? scheduleSearchService.findSchedulesAfterNowOnDay(petId, now, count)
+                : scheduleSearchService.findScheduleByPetIdOnDate(petId, now);
 
         List<ScheduleInfoDto.ScheduleInfo> scheduleInfo = schedules.stream()
                 .map(schedule -> ScheduleInfoDto.ScheduleInfo.from(schedule, new ArrayList<>())).toList();
@@ -57,12 +57,10 @@ public class ScheduleManageService {
 
     @Transactional(readOnly = true)
     public ScheduleInfoDto findPetSchedules(Long userId, LocalDateTime date) {
-        // 1. user가 관리하는 반려동물 목록 조회
         List<Pet> pets = memberSearchService.findAllManagerByMemberId(userId)
                 .stream().map(Manager::getPet).toList();
         List<Long> petIds = pets.stream().map(Pet::getId).toList();
 
-        // 2. 반려동물 목록에 해당하는 스케줄 조회
         List<ScheduleInfoDto.ScheduleInfo> scheduleInfo = scheduleSearchService.findSchedulesByCalender(date, petIds);
         return ScheduleInfoDto.of(scheduleInfo);
     }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSaveService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSaveService.java
@@ -1,0 +1,13 @@
+package com.kcy.fitapet.domain.schedule.service.module;
+
+import com.kcy.fitapet.domain.schedule.dao.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ScheduleSaveService {
+    private final ScheduleRepository scheduleRepository;
+}

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSaveService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSaveService.java
@@ -1,6 +1,7 @@
 package com.kcy.fitapet.domain.schedule.service.module;
 
 import com.kcy.fitapet.domain.schedule.dao.ScheduleRepository;
+import com.kcy.fitapet.domain.schedule.domain.Schedule;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,4 +11,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ScheduleSaveService {
     private final ScheduleRepository scheduleRepository;
+
+    public Schedule saveSchedule(Schedule schedule) {
+        return scheduleRepository.save(schedule);
+    }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSearchService.java
@@ -1,0 +1,13 @@
+package com.kcy.fitapet.domain.schedule.service.module;
+
+import com.kcy.fitapet.domain.schedule.dao.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ScheduleSearchService {
+    private final ScheduleRepository scheduleRepository;
+}

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSearchService.java
@@ -3,6 +3,7 @@ package com.kcy.fitapet.domain.schedule.service.module;
 import com.kcy.fitapet.domain.schedule.dao.ScheduleQueryRepository;
 import com.kcy.fitapet.domain.schedule.dao.ScheduleRepository;
 import com.kcy.fitapet.domain.schedule.domain.Schedule;
+import com.kcy.fitapet.domain.schedule.dto.ScheduleInfoDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,8 +24,25 @@ public class ScheduleSearchService {
         return scheduleRepository.findAllById(petId);
     }
 
+    /**
+     * 오늘 날짜의 현재 시간 이후에 해당하는 스케줄 조회
+     * @param petId 반려동물 id
+     * @param scheduleDate 조회할 날짜
+     * @param count 조회할 스케줄 개수
+     * @return 조회된 스케줄 리스트
+     */
+    // TODO: 현재 시간까지 고려
     @Transactional(readOnly = true)
     public List<Schedule> findSchedules(Long petId, LocalDateTime scheduleDate, Integer count) {
         return scheduleQueryRepository.findTopCountScheduleByIdOnDate(petId, scheduleDate, count);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ScheduleInfoDto.ScheduleInfo> findSchedulesByCalender(
+            Long userId,
+            LocalDateTime date,
+            List<Long> petIds
+    ) {
+        return scheduleQueryRepository.findSchedulesByCalender(userId, date, petIds);
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSearchService.java
@@ -1,13 +1,30 @@
 package com.kcy.fitapet.domain.schedule.service.module;
 
+import com.kcy.fitapet.domain.schedule.dao.ScheduleQueryRepository;
 import com.kcy.fitapet.domain.schedule.dao.ScheduleRepository;
+import com.kcy.fitapet.domain.schedule.domain.Schedule;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class ScheduleSearchService {
     private final ScheduleRepository scheduleRepository;
+    private final ScheduleQueryRepository scheduleQueryRepository;
+
+    @Transactional(readOnly = true)
+    public List<Schedule> findSchedules(Long petId) {
+        return scheduleRepository.findAllById(petId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Schedule> findSchedules(Long petId, LocalDateTime scheduleDate, Integer count) {
+        return scheduleQueryRepository.findTopCountScheduleByIdOnDate(petId, scheduleDate, count);
+    }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSearchService.java
@@ -20,8 +20,8 @@ public class ScheduleSearchService {
     private final ScheduleQueryRepository scheduleQueryRepository;
 
     @Transactional(readOnly = true)
-    public List<Schedule> findSchedules(Long petId) {
-        return scheduleRepository.findAllById(petId);
+    public List<Schedule> findScheduleByPetIdOnDate(Long petId, LocalDateTime date) {
+        return scheduleQueryRepository.findScheduleByPetIdOnDate(petId, date);
     }
 
     /**
@@ -33,8 +33,8 @@ public class ScheduleSearchService {
      */
     // TODO: 현재 시간까지 고려
     @Transactional(readOnly = true)
-    public List<Schedule> findSchedules(Long petId, LocalDateTime scheduleDate, Integer count) {
-        return scheduleQueryRepository.findTopCountScheduleByIdOnDate(petId, scheduleDate, count);
+    public List<Schedule> findSchedulesAfterNowOnDay(Long petId, LocalDateTime scheduleDate, Integer count) {
+        return scheduleQueryRepository.findTopCountSchedulesByIdOnDate(petId, scheduleDate, count);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSearchService.java
@@ -38,11 +38,10 @@ public class ScheduleSearchService {
     }
 
     @Transactional(readOnly = true)
-    public List<ScheduleInfoDto.ScheduleInfo> findSchedulesByCalender(
-            Long userId,
+    public List<ScheduleInfoDto.ScheduleQueryDslRes> findSchedulesByCalender(
             LocalDateTime date,
             List<Long> petIds
     ) {
-        return scheduleQueryRepository.findSchedulesByCalender(userId, date, petIds);
+        return scheduleQueryRepository.findSchedulesByCalender(date, petIds);
     }
 }

--- a/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/schedule/service/module/ScheduleSearchService.java
@@ -38,7 +38,7 @@ public class ScheduleSearchService {
     }
 
     @Transactional(readOnly = true)
-    public List<ScheduleInfoDto.ScheduleQueryDslRes> findSchedulesByCalender(
+    public List<ScheduleInfoDto.ScheduleInfo> findSchedulesByCalender(
             LocalDateTime date,
             List<Long> petIds
     ) {

--- a/src/main/java/com/kcy/fitapet/global/common/response/SuccessResponse.java
+++ b/src/main/java/com/kcy/fitapet/global/common/response/SuccessResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
 import java.util.Map;
 
 /**

--- a/src/main/java/com/kcy/fitapet/global/common/util/cookie/CookieUtil.java
+++ b/src/main/java/com/kcy/fitapet/global/common/util/cookie/CookieUtil.java
@@ -3,7 +3,6 @@ package com.kcy.fitapet.global.common.util.cookie;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/kcy/fitapet/global/config/CustomHibernate5Templates.java
+++ b/src/main/java/com/kcy/fitapet/global/config/CustomHibernate5Templates.java
@@ -1,0 +1,13 @@
+package com.kcy.fitapet.global.config;
+
+import com.querydsl.jpa.DefaultQueryHandler;
+import com.querydsl.jpa.Hibernate5Templates;
+import com.querydsl.jpa.QueryHandler;
+import org.hibernate.query.internal.QueryHelper;
+
+public class CustomHibernate5Templates extends Hibernate5Templates {
+    @Override
+    public QueryHandler getQueryHandler() {
+        return DefaultQueryHandler.DEFAULT;
+    }
+}

--- a/src/main/java/com/kcy/fitapet/global/config/CustomHibernate5Templates.java
+++ b/src/main/java/com/kcy/fitapet/global/config/CustomHibernate5Templates.java
@@ -3,7 +3,6 @@ package com.kcy.fitapet.global.config;
 import com.querydsl.jpa.DefaultQueryHandler;
 import com.querydsl.jpa.Hibernate5Templates;
 import com.querydsl.jpa.QueryHandler;
-import org.hibernate.query.internal.QueryHelper;
 
 public class CustomHibernate5Templates extends Hibernate5Templates {
     @Override

--- a/src/main/java/com/kcy/fitapet/global/config/QueryDslConfig.java
+++ b/src/main/java/com/kcy/fitapet/global/config/QueryDslConfig.java
@@ -13,6 +13,6 @@ public class QueryDslConfig {
 
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(new CustomHibernate5Templates(), entityManager);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -174,8 +174,8 @@ oauth2:
         client-name: Google
       apple:
         jwks-uri: ${APPLE_JWKS_URI}
-        client-id: "client-id"
-        client-secret: "client-secret"
+        client-id: ${APPLE_CLIENT_ID}
+        client-secret: ${APPLE_CLIENT_SECRET}
         client-name: Apple
 
 springdoc:

--- a/src/test/java/com/kcy/lib/DateTimeTest.java
+++ b/src/test/java/com/kcy/lib/DateTimeTest.java
@@ -31,4 +31,13 @@ public class DateTimeTest {
         // then
         System.out.println("age = " + age);
     }
+
+    @Test
+    public void testLocalDateTimeAddInteger() {
+        LocalDateTime now = LocalDateTime.now();
+        Integer notifyTime = 30;
+
+        LocalDateTime notifyDateTime = now.plusMinutes(notifyTime);
+        System.out.println("notifyDateTime = " + notifyDateTime);
+    }
 }


### PR DESCRIPTION
## 작업 이유
- 일정 등록
- 임의의 반려동물의 오늘 일정 리스트 조회
- 임의의 반려동물의 오늘 및 현재 시간 이후의 일정 부분 리스트 조회
- 임의의 유저가 관리하는 전체 반려동물의 임의의 날짜에 해당하는 일정 리스트 조회

## 작업 사항
> ⚠️ 아직 서버에 반영 안 되어 있습니다. 집에서 반영하고 다시 말씀드릴게요.

### 1️⃣ 일정 등록
- 요청 경로 : `POST /api/v2/users/1/pets/3/schedules`
- 요청 포맷
```json
{
    "scheduleName" : "스케줄명",
    "location" : "위치",
    "reservationDate" : "yyyy-MM-dd HH:mm:ss",
    "notifyTime" : "분 단위 정수값",
    "petIds" : ["함께 등록할 반려동물 pk값 배열"]
}
```
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/05713061-5c9c-4de6-80f1-52f3a994f7c2)

- 응답 포맷 success null

<br/>

### 2️⃣ 임의의 반려동물의 오늘 일정 리스트 조회
- 요청 경로 : `GET /api/v2/users/1/pets/3/schedules`
```json
{
    "status": "success",
    "data": {
        "schedules": [
            {
                "reservationDate": "yyyy-MM-dd HH:mm:ss",
                "scheduleId": , # schedule pk값
                "scheduleName": " ",
                "location": " "
            },
            ...
        ]
    }
}
```
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/198c0455-b32e-451a-9a00-950c07d6b6dc)


<br/>

### 3️⃣ 임의의 반려동물의 오늘 및 현재 시간 이후의 일정 부분 리스트 조회
- 요청 경로 : `GET /api/v2/users/1/pets/3/schedules?count=`
   - count 개수만큼 조회합니다.
   - `오늘 날짜`에 해당하는 `요청 이후 시간`만을 반환합니다.
- 응답 포맷
   - 위와 동일

![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/c6d4e3e0-ee76-435d-8eb5-e1db57dbcb39)


<br/>

### 4️⃣ 임의의 유저가 관리하는 전체 반려동물의 임의의 날짜에 해당하는 일정 리스트 조회
- 요청 경로 : `GET /api/v2/users/1/schedules?year=&month=&day=`
   - 만약 2024년 1월 23일이면, `/api/v2/users/1/schedules?year=2024&month=1&day=23`가 요청 경로가 됩니다.
- 응답 포맷
```json
{
    "status": "success",
    "data": {
        "schedules": [
            {
                "reservationDate": "yyyy-MM-dd HH:mm:ss",
                "scheduleId": , # 해당 일정 pk
                "scheduleName": "일정 이름",
                "location": "장소",
                "pets": [ # 해당 일정에 참여하는 반려동물 리스트
                    {
                        "petId": , # 반려동물 pk값
                        "petProfileImage": "" # 반려동물 프로필 사진 경로
                    },
                    {
                        "petId": ,
                        "petProfileImage": ""
                    }
                ]
            },
            ...
        ]
    }
}
```
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/7a0a25ed-0684-43ae-84d3-887a6c3ba7cf)


<br/>

### 🧐 더 고민해야 할 점
처음 Join 횟수를 3개 테이블에서 2개 테이블로 줄이기 위해 고안했던 것이  
`schedule`, `pet_schedule` 테이블만 Join해서 schedule 정보와 관련 `pet_id 리스트`를 가져온 후  
해당 pet_id 정보들을 중복 없이 추출하여 `findAll`하는 전략을 취했다.

하지만 코드 복잡도와 경직도가 높아진다는 문제로 인하여 Join을 최적화하기 위한 전략을 구상하는 것으로 방향을 바꾸었다.  

![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/08226346-a90e-4ef7-9a4a-459990cfedc4)  
가장 처음엔 `member_id`만으로 Sub Query와 Join을 사용하였으나, cost가 높아서 사용할 수 없었다.

따라서, `member_id`로 `manager` 테이블에서 관리 중인 반려동물의 `pet_id 리스트`를 요청하는 로직을 분리하고,  
해당 값을 QueryDsl의 인자로 넘겨줌으로써 cost를 낮출 수 있었다.

![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/7dc93305-c460-46e3-b928-76378b38231c)

하지만 여전히 `Full Table Scan`이 발생하는 등, 데이터가 커지면 요청이 오래 걸릴 수 있다는 우려가 존재한다.  
View를 생성했을 때, 더 좋은 이점을 취할 수 있을까?  
보다 더 많은 연구가 필요하다.

<br/>

## 이슈 연결
close #84 
