### PR TITLE
🔧 프론트 측 요구사항 및 일부 버그 픽스

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 - [프론트엔드](https://github.com/KCY-Fit-a-Pet/fit-a-pet-client): [최희진](https://github.com/heejinnn)
 - 백엔드: [양재서](https://github.com/psychology50)
 
+## [개발 기록]
+- [Side Project: Kakao Chat CI](https://jaeseo0519.tistory.com/323)
+- [NCP Cloud Function & Object Storage presigned URL 발급](https://jaeseo0519.tistory.com/331)
+- [Service Layer 분리에 대하여](https://jaeseo0519.tistory.com/314)
+- [API 세분화에 대하여](https://jaeseo0519.tistory.com/341)
+- [OIDC OAuth2 인증](https://jaeseo0519.tistory.com/349)
+- [Nginx 구성과 HTTPS 설정](https://jaeseo0519.tistory.com/354)
+- [GitHub Action & NCP CD pipeline 구축](https://jaeseo0519.tistory.com/354)
+
 ## [ Contents ]
 - [Project Summary](#project-summary)
 - [Version Control](#version-control)

--- a/src/main/java/com/kcy/fitapet/domain/care/service/component/CareManageService.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/service/component/CareManageService.java
@@ -7,12 +7,12 @@ import com.kcy.fitapet.domain.care.dto.CareCategoryDto;
 import com.kcy.fitapet.domain.care.dto.CareInfoRes;
 import com.kcy.fitapet.domain.care.dto.CareSaveReq;
 import com.kcy.fitapet.domain.care.exception.CareErrorCode;
-import com.kcy.fitapet.domain.care.service.module.CareSaveService;
+import com.kcy.fitapet.domain.care.service.module.CareUpdateService;
 import com.kcy.fitapet.domain.care.service.module.CareSearchService;
 import com.kcy.fitapet.domain.care.type.WeekType;
 import com.kcy.fitapet.domain.log.domain.CareLog;
 import com.kcy.fitapet.domain.log.dto.CareLogInfo;
-import com.kcy.fitapet.domain.log.service.CareLogSaveService;
+import com.kcy.fitapet.domain.log.service.CareLogUpdateService;
 import com.kcy.fitapet.domain.log.service.CareLogSearchService;
 import com.kcy.fitapet.domain.member.service.module.MemberSearchService;
 import com.kcy.fitapet.domain.pet.domain.Pet;
@@ -32,13 +32,13 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class CareManageService {
-    private final CareSaveService careSaveService;
+    private final CareUpdateService careUpdateService;
 
     private final MemberSearchService memberSearchService;
     private final PetSearchService petSearchService;
     private final CareSearchService careSearchService;
     private final CareLogSearchService careLogSearchService;
-    private final CareLogSaveService careLogSaveService;
+    private final CareLogUpdateService careLogUpdateService;
 
     @Transactional
     public List<?> findCareCategoryNamesByPetId(Long petId) {
@@ -84,14 +84,13 @@ public class CareManageService {
         }
 
         // TODO: 케어 등록 시간 10분 전부터 수행할 수 있도록 조건 추가?
-
         LocalDateTime today = LocalDateTime.now();
         if (careLogSearchService.existsByCareDateIdOnLogDate(careDateId, today)) {
             log.warn("이미 케어를 수행한 기록이 존재합니다.");
             throw new GlobalErrorException(CareErrorCode.ALREADY_CARED);
         }
 
-        CareLog careLog = careLogSaveService.save(CareLog.of(careDate));
+        CareLog careLog = careLogUpdateService.save(CareLog.of(careDate));
         log.info("careLog: {}", careLog);
         return CareLogInfo.of(careLog.getLogDate(), memberSearchService.findById(userId).getUid());
     }
@@ -120,13 +119,13 @@ public class CareManageService {
             List<CareSaveReq.AdditionalPetDto> additionalPetDtos
     ) {
         List<CareCategory> categories = findOrCreateCategories(categoryDto, additionalPetDtos);
-        careSaveService.saveCareCategories(categories);
+        careUpdateService.saveCareCategories(categories);
 
         List<Care> cares = createCares(categoryDto, careInfoDto, categories);
-        careSaveService.saveCares(cares);
+        careUpdateService.saveCares(cares);
 
         List<CareDate> dates = createCareDates(careInfoDto, cares);
-        careSaveService.saveCareDates(dates);
+        careUpdateService.saveCareDates(dates);
     }
 
     private List<CareCategory> findOrCreateCategories(

--- a/src/main/java/com/kcy/fitapet/domain/care/service/module/CareUpdateService.java
+++ b/src/main/java/com/kcy/fitapet/domain/care/service/module/CareUpdateService.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class CareSaveService {
+public class CareUpdateService {
     private final CareRepository careRepository;
     private final CareDateRepository careDateRepository;
     private final CareCategoryRepository careCategoryRepository;

--- a/src/main/java/com/kcy/fitapet/domain/log/service/CareLogUpdateService.java
+++ b/src/main/java/com/kcy/fitapet/domain/log/service/CareLogUpdateService.java
@@ -1,14 +1,14 @@
 package com.kcy.fitapet.domain.log.service;
 
-import com.kcy.fitapet.domain.care.domain.Care;
 import com.kcy.fitapet.domain.log.dao.CareLogRepository;
 import com.kcy.fitapet.domain.log.domain.CareLog;
+import com.kcy.fitapet.domain.log.domain.CareLogId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class CareLogSaveService {
+public class CareLogUpdateService {
     private final CareLogRepository careLogRepository;
 
     public CareLog save(CareLog careLog) {

--- a/src/main/java/com/kcy/fitapet/domain/memo/api/MemoApi.java
+++ b/src/main/java/com/kcy/fitapet/domain/memo/api/MemoApi.java
@@ -17,6 +17,7 @@ import org.apache.http.HttpStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -89,7 +90,10 @@ public class MemoApi {
     public ResponseEntity<?> getMemosAndSubCategories(
             @PathVariable("pet_id") Long petId, @PathVariable("memo_category_id") Long memoCategoryId,
             @RequestParam(value = "search", defaultValue = "", required = false) String search,
-            @PageableDefault(size = 15, page = 0, sort = "memo.createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 5, page = 0) @SortDefault.SortDefaults({
+                    @SortDefault(sort = "memo.createdAt", direction = Sort.Direction.DESC),
+                    @SortDefault(sort = "memoImage.id", direction = Sort.Direction.ASC)}
+            ) Pageable pageable
     ) {
         MemoInfoDto.PageResponse res = memoManageService.findMemosInMemoCategory(memoCategoryId, pageable, search);
         return ResponseEntity.ok(SuccessResponse.from(res));
@@ -112,7 +116,10 @@ public class MemoApi {
     @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId)")
     public ResponseEntity<?> getMemosByPet(
             @PathVariable("pet_id") Long petId,
-            @PageableDefault(size = 5, page = 0, sort = "memo.createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 5, page = 0) @SortDefault.SortDefaults({
+                    @SortDefault(sort = "memo.createdAt", direction = Sort.Direction.DESC),
+                    @SortDefault(sort = "memoImage.id", direction = Sort.Direction.ASC)}
+            ) Pageable pageable
     ) {
         MemoInfoDto.PageResponse res = memoManageService.findMemosByPetId(petId, pageable);
         return ResponseEntity.ok(SuccessResponse.from(res));

--- a/src/main/java/com/kcy/fitapet/domain/memo/dao/MemoQueryDslRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/memo/dao/MemoQueryDslRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 public interface MemoQueryDslRepository {
     Optional<MemoInfoDto.MemoInfo> findMemoAndMemoImageUrlsById(Long memoId);
-    Slice<MemoInfoDto.MemoInfo> findMemosInMemoCategory(Long memoCategoryId, Pageable pageable, String target);
-    Slice<MemoInfoDto.MemoInfo> findMemosByPetId(Long petId, Pageable pageable);
+    Slice<MemoInfoDto.MemoSummaryInfo> findMemosInMemoCategory(Long memoCategoryId, Pageable pageable, String target);
+    Slice<MemoInfoDto.MemoSummaryInfo> findMemosByPetId(Long petId, Pageable pageable);
 }

--- a/src/main/java/com/kcy/fitapet/domain/memo/dto/MemoInfoDto.java
+++ b/src/main/java/com/kcy/fitapet/domain/memo/dto/MemoInfoDto.java
@@ -11,9 +11,11 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 public class MemoInfoDto {
@@ -42,10 +44,32 @@ public class MemoInfoDto {
         public MemoInfo(Long memoId, String categorySuffix, String title, String content, LocalDateTime createdAt, List<MemoImageInfo> memoImages) {
             this.memoId = memoId;
             this.categorySuffix = categorySuffix;
-            this.title = title.length() == 19 ? title + "..." : title;
-            this.content = content.length() == 16 ? content + "..." : content;
+            this.title = title;
+            this.content = content;
             this.createdAt = createdAt;
             this.memoImages = (memoImages == null) ? List.of() : memoImages;
+        }
+    }
+
+    @Builder
+    @Dto(name = "memo")
+    public record MemoSummaryInfo(
+            Long memoId,
+            String categorySuffix,
+            String title,
+            String content,
+            @JsonSerialize(using = LocalDateTimeSerializer.class)
+            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime createdAt,
+            MemoImageInfo memoImage
+    ) {
+        public MemoSummaryInfo(Long memoId, String categorySuffix, String title, String content, LocalDateTime createdAt, MemoImageInfo memoImage) {
+            this.memoId = memoId;
+            this.categorySuffix = categorySuffix;
+            this.title = title.length() == 19 ? title + "..." : title;
+            this.content = content.length() == 16 ? content.replace("\n", "  ") + "..." : content.replace("\n", "  ");
+            this.createdAt = createdAt;
+            this.memoImage = memoImage;
         }
     }
 
@@ -55,18 +79,18 @@ public class MemoInfoDto {
     ) {
         public MemoImageInfo(Long memoImageId, String imgUrl) {
             this.memoImageId = memoImageId;
-            this.imgUrl = imgUrl;
+            this.imgUrl = Objects.toString(imgUrl, "");
         }
     }
 
     public record PageResponse(
-            @Schema(description = "메모 목록") List<MemoInfo> memos,
+            @Schema(description = "메모 목록") List<?> memos,
             @Schema(description = "현재 페이지") int currentPageNumber,
             @Schema(description = "페이지 크기") int pageSize,
             @Schema(description = "현재 페이지의 데이터 개수") int numberOfElements,
             @Schema(description = "다음 페이지 존재 여부") boolean hasNext
     ) {
-        public static PageResponse from(@NotNull Slice<MemoInfo> page) {
+        public static PageResponse from(@NotNull Slice<?> page) {
             return new PageResponse(page.getContent(), page.getPageable().getPageNumber(), page.getPageable().getPageSize(), page.getNumberOfElements(), page.hasNext());
         }
     }

--- a/src/main/java/com/kcy/fitapet/domain/memo/dto/MemoInfoDto.java
+++ b/src/main/java/com/kcy/fitapet/domain/memo/dto/MemoInfoDto.java
@@ -1,6 +1,7 @@
 package com.kcy.fitapet.domain.memo.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.kcy.fitapet.domain.memo.domain.Memo;
@@ -74,7 +75,9 @@ public class MemoInfoDto {
     }
 
     public record MemoImageInfo(
+            @JsonInclude(JsonInclude.Include.NON_NULL)
             Long memoImageId,
+            @JsonInclude(JsonInclude.Include.NON_EMPTY)
             String imgUrl
     ) {
         public MemoImageInfo(Long memoImageId, String imgUrl) {

--- a/src/main/java/com/kcy/fitapet/domain/memo/service/module/MemoSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/memo/service/module/MemoSearchService.java
@@ -76,14 +76,14 @@ public class MemoSearchService {
 
     @Transactional(readOnly = true)
     public MemoInfoDto.PageResponse findMemosInMemoCategory(Long memoCategoryId, Pageable pageable, String target) {
-        Slice<MemoInfoDto.MemoInfo> page = memoRepository.findMemosInMemoCategory(memoCategoryId, pageable, target);
+        Slice<MemoInfoDto.MemoSummaryInfo> page = memoRepository.findMemosInMemoCategory(memoCategoryId, pageable, target);
 
         return MemoInfoDto.PageResponse.from(page);
     }
 
     @Transactional(readOnly = true)
     public MemoInfoDto.PageResponse findMemosByPetId(Long petId, Pageable pageable) {
-        Slice<MemoInfoDto.MemoInfo> page = memoRepository.findMemosByPetId(petId, pageable);
+        Slice<MemoInfoDto.MemoSummaryInfo> page = memoRepository.findMemosByPetId(petId, pageable);
 
         return MemoInfoDto.PageResponse.from(page);
     }

--- a/src/main/java/com/kcy/fitapet/domain/oauth/dao/OauthRepository.java
+++ b/src/main/java/com/kcy/fitapet/domain/oauth/dao/OauthRepository.java
@@ -8,7 +8,7 @@ import java.math.BigInteger;
 import java.util.Optional;
 
 public interface OauthRepository extends ExtendedJpaRepository<OauthAccount, Long> {
-    Optional<OauthAccount> findByOauthIdAndProvider(BigInteger oauthId, ProviderType provider);
-    boolean existsByOauthIdAndProvider(BigInteger oauthId, ProviderType provider);
+    Optional<OauthAccount> findByOauthIdAndProvider(String oauthId, ProviderType provider);
+    boolean existsByOauthIdAndProvider(String oauthId, ProviderType provider);
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/kcy/fitapet/domain/oauth/domain/OauthAccount.java
+++ b/src/main/java/com/kcy/fitapet/domain/oauth/domain/OauthAccount.java
@@ -19,7 +19,7 @@ public class OauthAccount extends DateAuditable {
     private Long id;
 
     @Column(name = "oauth_id")
-    private BigInteger oauthId;
+    private String oauthId;
     @Convert(converter = ProviderTypeConverter.class)
     private ProviderType provider;
     private String email;
@@ -29,14 +29,14 @@ public class OauthAccount extends DateAuditable {
     private Member member;
 
     @Builder
-    public OauthAccount(Long id, BigInteger oauthId, ProviderType provider, String email) {
+    public OauthAccount(Long id, String oauthId, ProviderType provider, String email) {
         this.id = id;
         this.oauthId = oauthId;
         this.provider = provider;
         this.email = email;
     }
 
-    public static OauthAccount of(BigInteger oauthId, ProviderType provider, String email) {
+    public static OauthAccount of(String oauthId, ProviderType provider, String email) {
         return OauthAccount.builder()
                 .oauthId(oauthId)
                 .provider(provider)

--- a/src/main/java/com/kcy/fitapet/domain/oauth/service/module/OauthSearchService.java
+++ b/src/main/java/com/kcy/fitapet/domain/oauth/service/module/OauthSearchService.java
@@ -18,7 +18,7 @@ public class OauthSearchService {
     private final OauthRepository oauthRepository;
 
     @Transactional(readOnly = true)
-    public boolean isExistMember(BigInteger oauthId, ProviderType provider) {
+    public boolean isExistMember(String oauthId, ProviderType provider) {
         return oauthRepository.existsByOauthIdAndProvider(oauthId, provider);
     }
 
@@ -28,7 +28,7 @@ public class OauthSearchService {
     }
 
     @Transactional(readOnly = true)
-    public Member findMemberByOauthIdAndProvider(BigInteger oauthId, ProviderType provider) {
+    public Member findMemberByOauthIdAndProvider(String oauthId, ProviderType provider) {
         OauthAccount oauthAccount = oauthRepository.findByOauthIdAndProvider(oauthId, provider)
                 .orElseThrow(() -> new GlobalErrorException(OauthException.NOT_FOUND_MEMBER));
         return oauthAccount.getMember();

--- a/src/main/java/com/kcy/fitapet/global/common/util/querydsl/RepositorySliceHelper.java
+++ b/src/main/java/com/kcy/fitapet/global/common/util/querydsl/RepositorySliceHelper.java
@@ -7,6 +7,12 @@ import org.springframework.data.domain.SliceImpl;
 import java.util.List;
 
 public class RepositorySliceHelper {
+    /**
+     * List로 받은 contents를 Slice로 변환한다.
+     * @param contents : 변환할 List
+     * @param pageable : Pageable
+     * @return Slice<T> : 변환된 Slice. 단, contents.size()가 pageable.getPageSize()보다 작을 경우 hasNext는 true이며, Slice의 size는 contents.size() - 1이다.
+     */
     public static <T> Slice<T> toSlice(List<T> contents, Pageable pageable) {
         boolean hasNext = isContentSizeGreaterThanPageSize(contents, pageable);
         return new SliceImpl<>(hasNext ? subListLastContent(contents, pageable) : contents, pageable, hasNext);
@@ -16,7 +22,6 @@ public class RepositorySliceHelper {
         return pageable.isPaged() && content.size() > pageable.getPageSize();
     }
 
-    // 데이터 1개 빼고 반환
     private static <T> List<T> subListLastContent(List<T> content, Pageable pageable) {
         return content.subList(0, pageable.getPageSize());
     }


### PR DESCRIPTION
## 작업 이유
- 자잘한 버그 픽스
- 프론트 측 요구사항 API 반영

## 작업 사항
> ⚠️ `pet_id`를 반환하는 부분에 대해서는 전체 회의 때 다시 이야기 해봐요

### 1️⃣ Memo Image
- 데이터가 없는 경우, 빈 오브젝트 `{}` 반환
- 단건 조회 외의 메모 리스트 조회에서 가져오는 image는 언제나 가장 먼저 등록된 image를 가져옴.
   - ex. 1번 memo에 1, 2, 3, 4 memo_image가 있으면, 언제나 1번 memo_image만을 가져옴
![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/068fdbed-08bb-4123-9784-86332d648fa9)

<br/>

### 2️⃣ Memo 리스트 조회 시, `\n`문자가 포함되어 있으면 공백 두 개(`"  "`)로 치환
- 단, title에서는 개행을 허락하지 않음을 가정하고 별도로 처리하지 않음

![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/79658dfd-e104-4e04-9a92-7dd3ca1d955a)

<br/>

### 3️⃣ OIDC Token 저장 방식을 정수값에서 문자열로 변경
- Apple의 홍대병으로 인한 이슈
- 단, 이 부분은 프론트와 연동해서 이전 Oauth 연동을 비롯해 정상 동작하는지 확인이 필요함.


## 이슈 연결
close #96 #94 