### PR TITLE
🐛 accessToken → Authorization header로 변경

### DIFF
--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/auth/controller/AuthApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/auth/controller/AuthApi.java
@@ -42,8 +42,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
-import static kr.co.fitapet.api.common.security.jwt.consts.AuthConstants.ACCESS_TOKEN;
-import static kr.co.fitapet.api.common.security.jwt.consts.AuthConstants.REFRESH_TOKEN;
+import static kr.co.fitapet.api.common.security.jwt.consts.AuthConstants.*;
 
 
 @Tag(name = "유저 관리 API", description = "유저 인증과 관련된 API")
@@ -98,7 +97,7 @@ public class AuthApi {
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .header(ACCESS_TOKEN.getValue(), token.accessToken())
+                .header(AUTH_HEADER.getValue(), token.accessToken())
                 .body(SuccessResponse.from(Map.of("member", "등록된 oauth 계정 연동 성공")));
     }
 
@@ -183,7 +182,7 @@ public class AuthApi {
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .header(ACCESS_TOKEN.getValue(), tokens.accessToken())
+                .header(AUTH_HEADER.getValue(), tokens.accessToken())
                 .body(SuccessResponse.noContent());
     }
 
@@ -205,7 +204,7 @@ public class AuthApi {
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .header(ACCESS_TOKEN.getValue(), tokens.accessToken())
+                .header(AUTH_HEADER.getValue(), tokens.accessToken())
                 .body(SuccessResponse.from(Map.of("userId", userId)));
     }
 }

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/oauth/controller/OauthApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/oauth/controller/OauthApi.java
@@ -29,8 +29,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Map;
 import java.util.Optional;
 
-import static kr.co.fitapet.api.common.security.jwt.consts.AuthConstants.ACCESS_TOKEN;
-import static kr.co.fitapet.api.common.security.jwt.consts.AuthConstants.REFRESH_TOKEN;
+import static kr.co.fitapet.api.common.security.jwt.consts.AuthConstants.*;
 
 @Tag(name = "OAuth API")
 @RestController
@@ -109,7 +108,7 @@ public class OauthApi {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         else if (token.getValue().refreshToken() == null)
             return ResponseEntity.ok()
-                    .header(ACCESS_TOKEN.getValue(), token.getValue().accessToken())
+                    .header(AUTH_HEADER.getValue(), token.getValue().accessToken())
                     .body(SuccessResponse.from(Map.of("member", "신규 회원")));
 
         return getJwtResponseEntity(token.getKey(), token.getValue());
@@ -120,7 +119,7 @@ public class OauthApi {
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .header(ACCESS_TOKEN.getValue(), jwt.accessToken())
+                .header(AUTH_HEADER.getValue(), jwt.accessToken())
                 .body(SuccessResponse.from(Map.of("userId", userId)));
     }
 }

--- a/fitapet-app-external-api/src/main/resources/application.yml
+++ b/fitapet-app-external-api/src/main/resources/application.yml
@@ -52,11 +52,16 @@ spring:
 server:
   port: 8080
   forward-headers-strategy: framework
+  http2:
+    enabled: true
 
 spring:
   config:
     activate:
       on-profile: prod
+
+  main:
+    allow-bean-definition-overriding: true
 
   mvc:
     throw-exception-if-no-handler-found: true

--- a/fitapet-infra/src/main/resources/application-infra.yml
+++ b/fitapet-infra/src/main/resources/application-infra.yml
@@ -108,8 +108,23 @@ oauth2:
         client-name: Apple
 
 ncp:
-  api-key: ${NCP_API_ACCESS_KEY}
-  secret-key: ${NCP_SECRET_KEY}
+  credentials:
+    api-key: ${NCP_API_ACCESS_KEY}
+    secret-key: ${NCP_SECRET_KEY}
   sms:
     service-key: ${NCP_SMS_KEY}
     sender-phone: ${SENDER_PHONE}
+
+cloud:
+  aws:
+    s3:
+      endpoint: ${NCP_OBJECT_STORAGE_URI}
+      bucket: ${NCP_OBJECT_STORAGE_BUCKET}
+    credentials:
+      access-key: ${NCP_API_ACCESS_KEY}
+      secret-key: ${NCP_SECRET_KEY}
+    region:
+      static: ${NCP_OBJECT_STORAGE_REGION}
+      auto: false
+    stack:
+      auto: false

--- a/proxy/conf.d/default.conf
+++ b/proxy/conf.d/default.conf
@@ -28,7 +28,7 @@ server {
         ssl_certificate_key     /etc/letsencrypt/live/fitapet.co.kr/privkey.pem;
         include         /etc/letsencrypt/options-ssl-nginx.conf;
         ssl_dhparam     /etc/letsencrypt/ssl-dhparams.pem;
-
+        ssl_protocols TLSv1.2 TLSv1.3;
 
         access_log /var/log/nginx/access.log;
 


### PR DESCRIPTION
## 작업 이유

![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/36754b8c-008f-4340-bc32-31ccadfc128d)

- 자고 일어났는데 프론트에게서 살의를 느껴서 후다닥 작업..
- 하지만 내 잘못이 아닌 걸 → [url 맵 커스텀 헤더 만들기](https://cloud.google.com/load-balancing/docs/l7-internal/custom-headers?hl=ko)

## 작업 사항
- 기존의 모든 `accessToken` 응답 헤더를 `Authorization` 으로 변경
  - http 2.0 환경인 서버와 통신할 때는 `authorization` 필드로 전달될 수도 있음. 확인하고 거기에 맞춰서 클라이언트에서 변경해주어야 함.
- JwtAuthenticationFilter의 `HttpServletRequest` 클래스의 `getHeader()`는 대소문자를 구분하지 않기에, 별도의 처리 과정이 필요하지 않다.

![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/abac5f32-1fb2-4e2a-963d-9662b8e0eb0d)

## 이슈 연결
close #109 