### PR TITLE
✨ 전체 메모 조회 및 검색 API

### DIFF
--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/controller/AccountApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/controller/AccountApi.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import kr.co.fitapet.api.apis.profile.usecase.MemberAccountUseCase;
 import kr.co.fitapet.api.common.response.SuccessResponse;
 import kr.co.fitapet.api.common.security.authentication.CustomUserDetails;
@@ -21,6 +20,10 @@ import kr.co.fitapet.domain.domains.member.type.MemberAttrType;
 import kr.co.fitapet.domain.domains.notification.type.NotificationType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -148,6 +151,20 @@ public class AccountApi {
     @GetMapping("/{id}/memo-categories")
     @PreAuthorize("isAuthenticated() and #id == principal.userId")
     public ResponseEntity<?> getMemoCategories(@PathVariable("id") Long id) {
-        return ResponseEntity.ok(SuccessResponse.from("rootMemoCategories", memberAccountUseCase.getMemoCategories(id)));
+        return ResponseEntity.ok(SuccessResponse.from("rootMemoCategories", memberAccountUseCase.findMemoCategories(id)));
+    }
+
+    @Operation(summary = "관리 중인 반려동물의 모든 메모 조회")
+    @Parameter(name = "id", description = "조회할 프로필 ID", in = ParameterIn.PATH, required = true)
+    @GetMapping("/{id}/memos")
+    @PreAuthorize("isAuthenticated() and #userId == principal.userId")
+    public ResponseEntity<?> getMemos(
+            @PathVariable("id") Long userId,
+            @PageableDefault(size = 5, page = 0) @SortDefault.SortDefaults({
+                    @SortDefault(sort = "memo.createdAt", direction = Sort.Direction.DESC),
+                    @SortDefault(sort = "memoImage.id", direction = Sort.Direction.ASC)}
+            ) Pageable pageable
+    ) {
+        return ResponseEntity.ok(SuccessResponse.from(memberAccountUseCase.findMemos(userId, pageable)));
     }
 }

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/controller/AccountApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/controller/AccountApi.java
@@ -155,16 +155,24 @@ public class AccountApi {
     }
 
     @Operation(summary = "관리 중인 반려동물의 모든 메모 조회")
-    @Parameter(name = "id", description = "조회할 프로필 ID", in = ParameterIn.PATH, required = true)
+    @Parameters({
+            @Parameter(name = "id", description = "조회할 프로필 ID", in = ParameterIn.PATH, required = true),
+            @Parameter(name = "search", description = "검색어", in = ParameterIn.QUERY),
+            @Parameter(name = "size", description = "페이지 사이즈", example = "5", in = ParameterIn.QUERY),
+            @Parameter(name = "page", description = "페이지 번호", example = "1", in = ParameterIn.QUERY),
+            @Parameter(name = "sort", description = "정렬 기준", example = "createdAt", in = ParameterIn.QUERY),
+            @Parameter(name = "direction", description = "정렬 방식", example = "DESC" , in = ParameterIn.QUERY)
+    })
     @GetMapping("/{id}/memos")
     @PreAuthorize("isAuthenticated() and #userId == principal.userId")
     public ResponseEntity<?> getMemos(
             @PathVariable("id") Long userId,
+            @RequestParam(value = "search", defaultValue = "", required = false) String search,
             @PageableDefault(size = 5, page = 0) @SortDefault.SortDefaults({
                     @SortDefault(sort = "memo.createdAt", direction = Sort.Direction.DESC),
                     @SortDefault(sort = "memoImage.id", direction = Sort.Direction.ASC)}
             ) Pageable pageable
     ) {
-        return ResponseEntity.ok(SuccessResponse.from(memberAccountUseCase.findMemos(userId, pageable)));
+        return ResponseEntity.ok(SuccessResponse.from(memberAccountUseCase.findMemos(userId, pageable, search)));
     }
 }

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/usecase/MemberAccountUseCase.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/usecase/MemberAccountUseCase.java
@@ -145,11 +145,11 @@ public class MemberAccountUseCase {
     }
 
     @Transactional(readOnly = true)
-    public MemoInfoDto.PageResponse findMemos(Long userId, Pageable pageable) {
+    public MemoInfoDto.PageResponse findMemos(Long userId, Pageable pageable, String target) {
         List<Long> petIds = memberSearchService.findMyPetIds(userId);
         log.info("userId: {}, petIds: {}", userId, petIds);
 
-        return memoSearchService.findMemosByPetIds(petIds, pageable);
+        return memoSearchService.findMemosByPetIds(petIds, pageable, target);
     }
 
     /**

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/usecase/MemberAccountUseCase.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/usecase/MemberAccountUseCase.java
@@ -18,6 +18,7 @@ import kr.co.fitapet.domain.domains.member.exception.AccountErrorCode;
 import kr.co.fitapet.domain.domains.member.service.MemberSearchService;
 import kr.co.fitapet.domain.domains.member.type.MemberAttrType;
 import kr.co.fitapet.domain.domains.memo.dto.MemoCategoryInfoDto;
+import kr.co.fitapet.domain.domains.memo.dto.MemoInfoDto;
 import kr.co.fitapet.domain.domains.memo.service.MemoSearchService;
 import kr.co.fitapet.domain.domains.notification.type.NotificationType;
 import kr.co.fitapet.domain.domains.pet.domain.Pet;
@@ -26,6 +27,7 @@ import kr.co.fitapet.domain.domains.schedule.service.ScheduleSearchService;
 import kr.co.fitapet.infra.client.sms.snes.exception.SmsErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -128,7 +130,7 @@ public class MemberAccountUseCase {
     }
 
     @Transactional(readOnly = true)
-    public List<MemoCategoryInfoDto.MemoCategoryInfo> getMemoCategories(Long userId) {
+    public List<MemoCategoryInfoDto.MemoCategoryInfo> findMemoCategories(Long userId) {
         List<Long> petIds = memberSearchService.findMyPetIds(userId);
         log.info("userId: {}, petIds: {}", userId, petIds);
 
@@ -140,6 +142,14 @@ public class MemberAccountUseCase {
         }
 
         return rootMemoCategories;
+    }
+
+    @Transactional(readOnly = true)
+    public MemoInfoDto.PageResponse findMemos(Long userId, Pageable pageable) {
+        List<Long> petIds = memberSearchService.findMyPetIds(userId);
+        log.info("userId: {}, petIds: {}", userId, petIds);
+
+        return memoSearchService.findMemosByPetIds(petIds, pageable);
     }
 
     /**

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoQueryDslRepository.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoQueryDslRepository.java
@@ -11,5 +11,5 @@ public interface MemoQueryDslRepository {
     Optional<MemoInfoDto.MemoInfo> findMemoAndMemoImageUrlsById(Long memoId);
     Slice<MemoInfoDto.MemoSummaryInfo> findMemosInMemoCategory(Long memoCategoryId, Pageable pageable, String target);
     Slice<MemoInfoDto.MemoSummaryInfo> findMemosByPetId(Long petId, Pageable pageable);
-    Slice<MemoInfoDto.MemoSummaryInfo> findMemosByPetIds(List<Long> petIds, Pageable pageable);
+    Slice<MemoInfoDto.MemoSummaryInfo> findMemosByPetIds(List<Long> petIds, Pageable pageable, String target);
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoQueryDslRepository.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoQueryDslRepository.java
@@ -4,10 +4,12 @@ import kr.co.fitapet.domain.domains.memo.dto.MemoInfoDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemoQueryDslRepository {
     Optional<MemoInfoDto.MemoInfo> findMemoAndMemoImageUrlsById(Long memoId);
     Slice<MemoInfoDto.MemoSummaryInfo> findMemosInMemoCategory(Long memoCategoryId, Pageable pageable, String target);
     Slice<MemoInfoDto.MemoSummaryInfo> findMemosByPetId(Long petId, Pageable pageable);
+    Slice<MemoInfoDto.MemoSummaryInfo> findMemosByPetIds(List<Long> petIds, Pageable pageable);
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoQueryDslRepositoryImpl.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoQueryDslRepositoryImpl.java
@@ -130,6 +130,28 @@ public class MemoQueryDslRepositoryImpl implements MemoQueryDslRepository {
         return SliceUtil.toSlice(results, pageable);
     }
 
+    @Override
+    public Slice<MemoInfoDto.MemoSummaryInfo> findMemosByPetIds(List<Long> petIds, Pageable pageable) {
+        List<MemoInfoDto.MemoSummaryInfo> results = queryFactory
+                .from(memoCategory)
+                .leftJoin(memo).on(memo.memoCategory.id.eq(memoCategory.id))
+                .leftJoin(memoImage).on(memoImage.memo.id.eq(memo.id))
+                .where(memo.id.in(
+                        queryFactory
+                                .select(memo.id)
+                                .from(memoCategory)
+                                .leftJoin(memo).on(memo.memoCategory.id.eq(memoCategory.id))
+                                .where(memoCategory.pet.id.in(petIds))
+                                .orderBy(QueryDslUtil.getOrderSpecifier(pageable.getSort()).toArray(OrderSpecifier[]::new))
+                                .offset(pageable.getOffset())
+                                .limit(pageable.getPageSize() + 1)
+                ))
+                .orderBy(QueryDslUtil.getOrderSpecifier(pageable.getSort()).toArray(OrderSpecifier[]::new))
+                .transform(createMemoInfoDtoResultTransformer());
+
+        return SliceUtil.toSlice(results, pageable);
+    }
+
     private ResultTransformer<List<MemoInfoDto.MemoSummaryInfo>> createMemoInfoDtoResultTransformer() {
         return groupBy(memo.id).list(
                 Projections.constructor(

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoQueryDslRepositoryImpl.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoQueryDslRepositoryImpl.java
@@ -126,12 +126,13 @@ public class MemoQueryDslRepositoryImpl implements MemoQueryDslRepository {
                 ))
                 .orderBy(QueryDslUtil.getOrderSpecifier(pageable.getSort()).toArray(OrderSpecifier[]::new))
                 .transform(createMemoInfoDtoResultTransformer());
+        log.info("results: {}", results);
 
         return SliceUtil.toSlice(results, pageable);
     }
 
     @Override
-    public Slice<MemoInfoDto.MemoSummaryInfo> findMemosByPetIds(List<Long> petIds, Pageable pageable) {
+    public Slice<MemoInfoDto.MemoSummaryInfo> findMemosByPetIds(List<Long> petIds, Pageable pageable, String target) {
         List<MemoInfoDto.MemoSummaryInfo> results = queryFactory
                 .from(memoCategory)
                 .leftJoin(memo).on(memo.memoCategory.id.eq(memoCategory.id))
@@ -141,7 +142,9 @@ public class MemoQueryDslRepositoryImpl implements MemoQueryDslRepository {
                                 .select(memo.id)
                                 .from(memoCategory)
                                 .leftJoin(memo).on(memo.memoCategory.id.eq(memoCategory.id))
-                                .where(memoCategory.pet.id.in(petIds))
+                                .where(memoCategory.pet.id.in(petIds)
+                                        .and(QueryDslUtil.matchAgainstTwoElemBooleanMode(memo.title, memo.content, target))
+                                )
                                 .orderBy(QueryDslUtil.getOrderSpecifier(pageable.getSort()).toArray(OrderSpecifier[]::new))
                                 .offset(pageable.getOffset())
                                 .limit(pageable.getPageSize() + 1)

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/service/MemoSearchService.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/service/MemoSearchService.java
@@ -78,6 +78,13 @@ public class MemoSearchService {
     }
 
     @Transactional(readOnly = true)
+    public MemoInfoDto.PageResponse findMemosByPetIds(List<Long> petIds, Pageable pageable) {
+        Slice<MemoInfoDto.MemoSummaryInfo> page = memoRepository.findMemosByPetIds(petIds, pageable);
+
+        return MemoInfoDto.PageResponse.from(page);
+    }
+
+    @Transactional(readOnly = true)
     public List<MemoImage> findMemoImagesByMemoId(Long memoId) {
         return memoImageRepository.findByMemo_Id(memoId);
     }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/service/MemoSearchService.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/service/MemoSearchService.java
@@ -78,8 +78,8 @@ public class MemoSearchService {
     }
 
     @Transactional(readOnly = true)
-    public MemoInfoDto.PageResponse findMemosByPetIds(List<Long> petIds, Pageable pageable) {
-        Slice<MemoInfoDto.MemoSummaryInfo> page = memoRepository.findMemosByPetIds(petIds, pageable);
+    public MemoInfoDto.PageResponse findMemosByPetIds(List<Long> petIds, Pageable pageable, String target) {
+        Slice<MemoInfoDto.MemoSummaryInfo> page = memoRepository.findMemosByPetIds(petIds, pageable, target);
 
         return MemoInfoDto.PageResponse.from(page);
     }


### PR DESCRIPTION
## 작업 이유
> 허허, 실수로 브랜치를 새로 안 파고 전에 작업하던 브랜치에서 해버렸네요.
- UI 변경으로 인한 기능 스펙 변경 대응
- 관리 중인 전체 반려동물에게 등록된 메모를 대상으로 조회 및 검색하는 API 추가

## 작업 사항
- 요청: `GET /api/v2/accounts/{user_id}/memos`
   - 이전에 적어둔 [6️⃣ 카테고리 내 메모 리스트 조회 및 검색 (Pagenation 적용)](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/pull/91)과 요청 경로만 다릅니다.

![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/baa40bba-ae1f-40fb-bd6a-4a660d60348b)

<br/>

**⚠️ text 검색 시, `match percent`가 낮아서 검색이 안 되는 이슈**

![image](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/cd669fe6-b828-4b62-a6dd-5549768981af)

- 현재 MySQL의 Full Text Index를 사용하여 빠른 검색을 보장함.
- 다만, 특정 단어가 분명히 존재함에도 찾지 못하는 경우가 존재.
- 해당 부분은 추후 속도를 포기해서 `Like`를 사용하거나, 메모리를 포기해서 `Full Text Index with PARSER`를 적용해야 할 것 같다.

## 이슈 연결
close #116 