### PR TITLE
✨ Care 수정 및 삭제 API

### DIFF
--- a/fitapet-app-external-api/build.gradle
+++ b/fitapet-app-external-api/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     /* jackson */
     implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
 
+    /* java emoji */
+    implementation group: 'com.vdurmont', name: 'emoji-java', version: '5.1.1'
+
     implementation project(':fitapet-common')
     implementation project(':fitapet-domain')
     implementation project(':fitapet-infra')

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/controller/CareApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/controller/CareApi.java
@@ -9,8 +9,8 @@ import jakarta.validation.Valid;
 import kr.co.fitapet.api.apis.care.usecase.CareUseCase;
 import kr.co.fitapet.api.common.response.SuccessResponse;
 import kr.co.fitapet.api.common.security.authentication.CustomUserDetails;
-import kr.co.fitapet.domain.domains.care.dto.CareInfoRes;
-import kr.co.fitapet.domain.domains.care.dto.CareSaveReq;
+import kr.co.fitapet.api.apis.care.dto.CareInfoRes;
+import kr.co.fitapet.api.apis.care.dto.CareSaveReq;
 import kr.co.fitapet.domain.domains.care_log.dto.CareLogInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -70,10 +70,10 @@ public class CareApi {
     public ResponseEntity<?> updateCare(
             @PathVariable("pet_id") Long petId,
             @PathVariable("care_id") Long careId,
-//            @RequestBody @Valid CarePutReq request,
+            @RequestBody @Valid CareSaveReq.UpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
-//        careUseCase.updateCare(user.getUserId(), petId, careId, request);
+        careUseCase.updateCare(careId, request);
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/controller/CareApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/controller/CareApi.java
@@ -70,8 +70,7 @@ public class CareApi {
     public ResponseEntity<?> updateCare(
             @PathVariable("pet_id") Long petId,
             @PathVariable("care_id") Long careId,
-            @RequestBody @Valid CareSaveReq.UpdateRequest request,
-            @AuthenticationPrincipal CustomUserDetails user
+            @RequestBody @Valid CareSaveReq.UpdateRequest request
     ) {
         careUseCase.updateCare(careId, request);
         return ResponseEntity.ok(SuccessResponse.noContent());

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/controller/CareApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/controller/CareApi.java
@@ -2,6 +2,7 @@ package kr.co.fitapet.api.apis.care.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -51,6 +52,7 @@ public class CareApi {
     }
 
     @Operation(summary = "작성한 케어 카테고리 목록 조회")
+    @Parameter(name = "pet_id", description = "등록할 반려동물 ID", in = ParameterIn.PATH, required = true)
     @GetMapping("/categories")
     @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId)")
     public ResponseEntity<?> getCareCategoryNames(@PathVariable("pet_id") Long petId) {
@@ -58,7 +60,29 @@ public class CareApi {
         return ResponseEntity.ok(SuccessResponse.from("careCategories", careCategories));
     }
 
+    @Operation(summary = "케어 수정")
+    @Parameters({
+            @Parameter(name = "pet_id", description = "등록할 반려동물 ID", in = ParameterIn.PATH, required = true),
+            @Parameter(name = "care_id", description = "케어 ID", in = ParameterIn.PATH, required = true)
+    })
+    @PutMapping("/{care_id}")
+    @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId)")
+    public ResponseEntity<?> updateCare(
+            @PathVariable("pet_id") Long petId,
+            @PathVariable("care_id") Long careId,
+            @RequestBody @Valid CareSaveReq.Request request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+//        careUseCase.updateCare(careId, user.getUserId(), petId, request);
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
+
     @Operation(summary = "케어 수행")
+    @Parameters({
+            @Parameter(name = "pet_id", description = "등록할 반려동물 ID", in = ParameterIn.PATH, required = true),
+            @Parameter(name = "care_id", description = "케어 ID", in = ParameterIn.PATH, required = true),
+            @Parameter(name = "care_date_id", description = "케어 날짜 ID", in = ParameterIn.PATH, required = true)
+    })
     @GetMapping("/{care_id}/care-dates/{care_date_id}")
     @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId) and @careAuthorize.isValidCareAndCareDate(#petId, #careId, #careDateId)")
     public ResponseEntity<?> doCare(
@@ -69,5 +93,38 @@ public class CareApi {
     ) {
         CareLogInfo careLog = careUseCase.doCare(careDateId, user.getUserId());
         return ResponseEntity.ok(SuccessResponse.from(careLog));
+    }
+
+    @Operation(summary = "케어 수행 취소")
+    @Parameters({
+            @Parameter(name = "pet_id", description = "등록할 반려동물 ID", in = ParameterIn.PATH, required = true),
+            @Parameter(name = "care_id", description = "케어 ID", in = ParameterIn.PATH, required = true),
+            @Parameter(name = "care_date_id", description = "케어 날짜 ID", in = ParameterIn.PATH, required = true)
+    })
+    @DeleteMapping("/{care_id}/care-dates/{care_date_id}")
+    @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId) and @careAuthorize.isValidCareAndCareDate(#petId, #careId, #careDateId)")
+    public ResponseEntity<?> cancleCare(
+            @PathVariable("pet_id") Long petId,
+            @PathVariable("care_id") Long careId,
+            @PathVariable("care_date_id") Long careDateId
+    ) {
+        careUseCase.cancelCare(careDateId);
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
+
+    @Operation(summary = "케어 삭제")
+    @Parameters({
+            @Parameter(name = "pet_id", description = "등록할 반려동물 ID", in = ParameterIn.PATH, required = true),
+            @Parameter(name = "care_id", description = "케어 ID", in = ParameterIn.PATH, required = true)
+    })
+    @DeleteMapping("/{care_id}")
+    @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId)")
+    public ResponseEntity<?> deleteCare(
+            @PathVariable("pet_id") Long petId,
+            @PathVariable("care_id") Long careId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+//        careUseCase.deleteCare(careId, user.getUserId());
+        return ResponseEntity.ok(SuccessResponse.noContent());
     }
 }

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/controller/CareApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/controller/CareApi.java
@@ -51,6 +51,13 @@ public class CareApi {
         return ResponseEntity.ok(SuccessResponse.from("careCategories", res.getInfo()));
     }
 
+    @Operation(summary = "케어 날짜 리스트 조회 - 수정 페이지용")
+    @GetMapping("/{care_id}/care-dates")
+    @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId) and @careAuthorize.isValidCare(#petId, #careId)")
+    public ResponseEntity<?> getCare(@PathVariable("pet_id") Long petId, @PathVariable("care_id") Long careId) {
+        return ResponseEntity.ok(SuccessResponse.from("careDates", careUseCase.findCareDates(careId)));
+    }
+
     @Operation(summary = "작성한 케어 카테고리 목록 조회")
     @Parameter(name = "pet_id", description = "등록할 반려동물 ID", in = ParameterIn.PATH, required = true)
     @GetMapping("/categories")

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/controller/CareApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/controller/CareApi.java
@@ -66,14 +66,14 @@ public class CareApi {
             @Parameter(name = "care_id", description = "케어 ID", in = ParameterIn.PATH, required = true)
     })
     @PutMapping("/{care_id}")
-    @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId)")
+    @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId) and @careAuthorize.isValidCare(#petId, #careId)")
     public ResponseEntity<?> updateCare(
             @PathVariable("pet_id") Long petId,
             @PathVariable("care_id") Long careId,
-            @RequestBody @Valid CareSaveReq.Request request,
+//            @RequestBody @Valid CarePutReq request,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
-//        careUseCase.updateCare(careId, user.getUserId(), petId, request);
+//        careUseCase.updateCare(user.getUserId(), petId, careId, request);
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 
@@ -91,7 +91,7 @@ public class CareApi {
             @PathVariable("care_date_id") Long careDateId,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
-        CareLogInfo careLog = careUseCase.doCare(careDateId, user.getUserId());
+        CareLogInfo careLog = careUseCase.doCare(user.getUserId(), careDateId);
         return ResponseEntity.ok(SuccessResponse.from(careLog));
     }
 
@@ -118,13 +118,9 @@ public class CareApi {
             @Parameter(name = "care_id", description = "케어 ID", in = ParameterIn.PATH, required = true)
     })
     @DeleteMapping("/{care_id}")
-    @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId)")
-    public ResponseEntity<?> deleteCare(
-            @PathVariable("pet_id") Long petId,
-            @PathVariable("care_id") Long careId,
-            @AuthenticationPrincipal CustomUserDetails user
-    ) {
-//        careUseCase.deleteCare(careId, user.getUserId());
+    @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId) and @careAuthorize.isValidCare(#petId, #careId)")
+    public ResponseEntity<?> deleteCare(@PathVariable("pet_id") Long petId, @PathVariable("care_id") Long careId) {
+        careUseCase.deleteCare(careId);
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 }

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/dto/CareCategoryInfo.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/dto/CareCategoryInfo.java
@@ -1,4 +1,4 @@
-package kr.co.fitapet.domain.domains.care.dto;
+package kr.co.fitapet.api.apis.care.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/dto/CareInfoRes.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/dto/CareInfoRes.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 import com.vdurmont.emoji.EmojiParser;
+import kr.co.fitapet.domain.domains.care.domain.CareDate;
+import kr.co.fitapet.domain.domains.care.type.WeekType;
 import lombok.Getter;
 
 import java.time.LocalTime;
@@ -41,6 +43,18 @@ public class CareInfoRes {
     ) {
         public static CareDto of(Long careId, Long careDateId, String careName, LocalTime careDate, boolean isClear) {
             return new CareDto(careId, careDateId, EmojiParser.parseToUnicode(careName), careDate, isClear);
+        }
+    }
+
+    public record CareDateDto(
+            Long careDateId,
+            WeekType week,
+            @JsonSerialize(using = LocalTimeSerializer.class)
+            @JsonFormat(pattern = "HH:mm:ss")
+            LocalTime time
+    ) {
+        public static CareDateDto fromEntity(CareDate careDate) {
+            return new CareDateDto(careDate.getId(), careDate.getWeek(), careDate.getCareTime());
         }
     }
 }

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/dto/CareInfoRes.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/dto/CareInfoRes.java
@@ -1,13 +1,13 @@
-package kr.co.fitapet.domain.domains.care.dto;
+package kr.co.fitapet.api.apis.care.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import com.vdurmont.emoji.EmojiParser;
 import lombok.Getter;
 
 import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 @Getter
@@ -26,8 +26,7 @@ public class CareInfoRes {
         List<CareDto> cares
     ) {
         public static CareCategoryDto of(Long id, String categoryName, List<CareDto> cares) {
-            cares.sort(Comparator.comparing(CareDto::careDate));
-            return new CareCategoryDto(id, categoryName, cares);
+            return new CareCategoryDto(id, EmojiParser.parseToUnicode(categoryName), cares);
         }
     }
 
@@ -41,7 +40,7 @@ public class CareInfoRes {
             boolean isClear
     ) {
         public static CareDto of(Long careId, Long careDateId, String careName, LocalTime careDate, boolean isClear) {
-            return new CareDto(careId, careDateId, careName, careDate, isClear);
+            return new CareDto(careId, careDateId, EmojiParser.parseToUnicode(careName), careDate, isClear);
         }
     }
 }

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/dto/CareSaveReq.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/dto/CareSaveReq.java
@@ -3,12 +3,10 @@ package kr.co.fitapet.api.apis.care.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
-import com.vdurmont.emoji.EmojiLoader;
 import com.vdurmont.emoji.EmojiParser;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import kr.co.fitapet.domain.domains.care.domain.Care;
 import kr.co.fitapet.domain.domains.care.domain.CareCategory;
@@ -60,7 +58,7 @@ public class CareSaveReq {
             @Schema(description = "케어 이름", example = "1")
             @NotBlank
             String careName,
-            @NotNull
+            @NotNull @Valid
             List<CareDateDto> careDates,
             @Schema(description = "제한 시간(분 단위) - 제한 시간 없는 경우 0", example = "30")
             @NotNull
@@ -70,15 +68,14 @@ public class CareSaveReq {
             return Care.of(EmojiParser.parseToAliases(careName), limitTime, category);
         }
 
-        public List<CareDate> toCareDateEntity() {
-            return careDates.stream()
-                    .map(careDateDto -> CareDate.of(careDateDto.week(), careDateDto.time()))
-                    .toList();
+        @Override
+        public String careName() {
+            return EmojiParser.parseToAliases(careName);
         }
     }
 
     @Schema(description = "케어 등록 - 케어 날짜")
-    private record CareDateDto(
+    public record CareDateDto(
         @Schema(description = "요일", example = "mon")
         @NotNull
         WeekType week,
@@ -88,6 +85,9 @@ public class CareSaveReq {
         @NotNull
         LocalTime time
     ) {
+        public CareDate toEntity(Care care) {
+            return CareDate.of(week, time, care);
+        }
     }
 
     @Schema(description = "케어 동물 추가 - 기존 카테고리에 묶을 거면 categoryId, 새로 만들 거면 0")

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/dto/CareSaveReq.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/dto/CareSaveReq.java
@@ -1,10 +1,13 @@
-package kr.co.fitapet.domain.domains.care.dto;
+package kr.co.fitapet.api.apis.care.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import com.vdurmont.emoji.EmojiLoader;
+import com.vdurmont.emoji.EmojiParser;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import kr.co.fitapet.domain.domains.care.domain.Care;
 import kr.co.fitapet.domain.domains.care.domain.CareCategory;
@@ -28,6 +31,15 @@ public class CareSaveReq {
     ) {
     }
 
+    @Schema(description = "케어 수정 요청")
+    public record UpdateRequest(
+            @NotNull
+            CategoryDto category,
+            @NotNull
+            CareInfoDto care
+    ) {
+    }
+
     @Schema(description = "케어 등록 - 카테고리")
     public record CategoryDto(
         @Schema(description = "카테고리 ID", example = "1")
@@ -37,6 +49,11 @@ public class CareSaveReq {
         @NotNull
         String categoryName
     ) {
+        public CategoryDto(Long categoryId, String categoryName) {
+            this.categoryId = categoryId;
+            this.categoryName = EmojiParser.parseToAliases(categoryName);
+        }
+
         public CareCategory toCareCategory() {
             return CareCategory.of(categoryName);
         }
@@ -53,6 +70,12 @@ public class CareSaveReq {
             @NotNull
             Integer limitTime
     ) {
+        public CareInfoDto(String careName, List<CareDateDto> careDates, Integer limitTime) {
+            this.careName = EmojiParser.parseToAliases(careName);
+            this.careDates = careDates;
+            this.limitTime = limitTime;
+        }
+
         public Care toCare(CareCategory category) {
             return Care.of(careName, limitTime, category);
         }
@@ -60,9 +83,6 @@ public class CareSaveReq {
         public List<CareDate> toCareDateEntity() {
             return careDates.stream()
                     .map(careDateDto -> CareDate.of(careDateDto.week(), careDateDto.time()))
-                    .collect(toMap(CareDate::getWeek, careDate -> careDate, (o1, o2) -> o1))
-                    .values()
-                    .stream()
                     .toList();
         }
     }

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/dto/CareSaveReq.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/dto/CareSaveReq.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 import com.vdurmont.emoji.EmojiLoader;
 import com.vdurmont.emoji.EmojiParser;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -22,20 +23,20 @@ import static java.util.stream.Collectors.toMap;
 public class CareSaveReq {
     @Schema(description = "케어 등록 요청")
     public record Request(
-            @NotNull
+            @NotNull @Valid
             CategoryDto category,
-            @NotNull
+            @NotNull @Valid
             CareInfoDto care,
-            @NotNull
+            @NotNull @Valid
             List<AdditionalPetDto> pets
     ) {
     }
 
     @Schema(description = "케어 수정 요청")
     public record UpdateRequest(
-            @NotNull
+            @NotNull @Valid
             CategoryDto category,
-            @NotNull
+            @NotNull @Valid
             CareInfoDto care
     ) {
     }
@@ -46,16 +47,11 @@ public class CareSaveReq {
         @NotNull
         Long categoryId,
         @Schema(description = "카테고리 이름", example = "식사")
-        @NotNull
+        @NotBlank
         String categoryName
     ) {
-        public CategoryDto(Long categoryId, String categoryName) {
-            this.categoryId = categoryId;
-            this.categoryName = EmojiParser.parseToAliases(categoryName);
-        }
-
         public CareCategory toCareCategory() {
-            return CareCategory.of(categoryName);
+            return CareCategory.of(EmojiParser.parseToAliases(categoryName));
         }
     }
 
@@ -70,14 +66,8 @@ public class CareSaveReq {
             @NotNull
             Integer limitTime
     ) {
-        public CareInfoDto(String careName, List<CareDateDto> careDates, Integer limitTime) {
-            this.careName = EmojiParser.parseToAliases(careName);
-            this.careDates = careDates;
-            this.limitTime = limitTime;
-        }
-
         public Care toCare(CareCategory category) {
-            return Care.of(careName, limitTime, category);
+            return Care.of(EmojiParser.parseToAliases(careName), limitTime, category);
         }
 
         public List<CareDate> toCareDateEntity() {

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/mapper/CareMapper.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/mapper/CareMapper.java
@@ -1,0 +1,221 @@
+package kr.co.fitapet.api.apis.care.mapper;
+
+import kr.co.fitapet.api.apis.care.dto.CareSaveReq;
+import kr.co.fitapet.common.annotation.Mapper;
+import kr.co.fitapet.common.execption.GlobalErrorException;
+import kr.co.fitapet.domain.domains.care.domain.Care;
+import kr.co.fitapet.domain.domains.care.domain.CareCategory;
+import kr.co.fitapet.domain.domains.care.domain.CareDate;
+import kr.co.fitapet.api.apis.care.dto.CareInfoRes;
+import kr.co.fitapet.domain.domains.care.exception.CareErrorCode;
+import kr.co.fitapet.domain.domains.care.service.CareSaveService;
+import kr.co.fitapet.domain.domains.care.service.CareSearchService;
+import kr.co.fitapet.domain.domains.care.type.WeekType;
+import kr.co.fitapet.domain.domains.care_log.domain.CareLog;
+import kr.co.fitapet.domain.domains.care_log.service.CareLogSaveService;
+import kr.co.fitapet.domain.domains.care_log.service.CareLogSearchService;
+import kr.co.fitapet.domain.domains.pet.domain.Pet;
+import kr.co.fitapet.domain.domains.pet.service.PetSearchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.*;
+import java.util.stream.Stream;
+
+@Mapper
+@RequiredArgsConstructor
+@Slf4j
+public class CareMapper {
+    private final CareSaveService careSaveService;
+    private final CareSearchService careSearchService;
+    private final CareLogSearchService careLogSearchService;
+    private final CareLogSaveService careLogSaveService;
+
+    private final PetSearchService petSearchService;
+
+    @Transactional
+    public void saveCare(CareSaveReq.CategoryDto categoryDto, CareSaveReq.CareInfoDto careInfoDto, List<CareSaveReq.AdditionalPetDto> additionalPetDtos) {
+        persistAboutCare(categoryDto, careInfoDto, additionalPetDtos);
+    }
+
+    private void persistAboutCare(
+            CareSaveReq.CategoryDto categoryDto,
+            CareSaveReq.CareInfoDto careInfoDto,
+            List<CareSaveReq.AdditionalPetDto> additionalPetDtos
+    ) {
+        List<CareCategory> categories = findOrCreateCategories(categoryDto, additionalPetDtos);
+        careSaveService.saveCareCategories(categories);
+
+        List<Care> cares = createCares(careInfoDto, categories);
+        careSaveService.saveCares(cares);
+
+        List<CareDate> dates = createCareDates(careInfoDto, cares);
+        careSaveService.saveCareDates(dates);
+    }
+
+    private List<CareCategory> findOrCreateCategories(
+            CareSaveReq.CategoryDto categoryDto,
+            List<CareSaveReq.AdditionalPetDto> additionalPetDtos
+    ) {
+        List<CareCategory> categories = new ArrayList<>();
+        List<Long> unchangedCategoryIds = new ArrayList<>();
+
+        for (CareSaveReq.AdditionalPetDto additionalPetDto : additionalPetDtos) {
+            if (additionalPetDto.categoryId() != 0L) {
+                unchangedCategoryIds.add(additionalPetDto.categoryId());
+                continue;
+            }
+
+            if (categoryDto.categoryName().isBlank())
+                throw new GlobalErrorException(CareErrorCode.CATEGORY_NAME_IS_BLANK);
+
+            Pet pet = petSearchService.findPetById(additionalPetDto.petId());
+            CareCategory category = categoryDto.toCareCategory();
+            category.updatePet(pet);
+            categories.add(category);
+        }
+
+        categories.addAll(careSearchService.findCareCategoriesByIds(unchangedCategoryIds));
+        return categories;
+    }
+
+    private List<Care> createCares(CareSaveReq.CareInfoDto careInfoDto, List<CareCategory> categories) {
+        return categories.stream()
+                .map(careInfoDto::toCare)
+                .toList();
+    }
+
+    private List<CareDate> createCareDates(CareSaveReq.CareInfoDto careInfoDto, List<Care> cares) {
+        return cares.stream()
+                .flatMap(care -> careInfoDto.toCareDateEntity().stream()
+                        .peek(date -> date.updateCare(care)))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public CareInfoRes.CareCategoryDto mapToCareCategoryDto(CareCategory careCategory, LocalDateTime now) {
+        List<CareInfoRes.CareDto> careDtos = careCategory.getCares().stream()
+                .flatMap(care -> mapToCareDtos(care, now))
+                .sorted(Comparator.comparing(CareInfoRes.CareDto::careDate))
+                .toList();
+
+        return CareInfoRes.CareCategoryDto.of(careCategory.getId(), careCategory.getCategoryName(), careDtos);
+    }
+
+    private Stream<CareInfoRes.CareDto> mapToCareDtos(Care care, LocalDateTime now) {
+        WeekType todayWeek = WeekType.fromLegacyType(now.getDayOfWeek().toString());
+
+        return careSearchService.findCareDatesFromCareIdAndWeek(care.getId(), todayWeek).stream()
+                .map(careDate -> {
+                    boolean isClear = careLogSearchService.existsByCareDateIdOnLogDate(careDate.getId(), now);
+                    return CareInfoRes.CareDto.of(care.getId(), careDate.getId(), care.getCareName(), careDate.getCareTime(), isClear);
+                });
+    }
+
+    @Transactional
+    public void updateCareCategory(Care care, CareCategory category, CareSaveReq.CategoryDto requestCategory) {
+        // careCategory 갱신 여부
+        // request.category().categoryId() == category.getId() -> 카테고리 변경 없음
+        // request.category().categoryId() == 0L -> 카테고리 신규 생성 후 변경
+        // request.category().categoryId() != category.getId() -> 다른 카테고리 이동 후, 기존 카테고리에 케어가 없을 경우 삭제
+        if (requestCategory.categoryId() == 0L) {
+            CareCategory newCategory = CareCategory.of(requestCategory.categoryName());
+            newCategory.updatePet(category.getPet());
+            careSaveService.saveCareCategory(newCategory);
+            care.updateCareCategory(newCategory);
+        } else if (!requestCategory.categoryId().equals(category.getId())) {
+            CareCategory newCategory = careSearchService.findCareCategoryById(requestCategory.categoryId());
+            care.updateCareCategory(newCategory);
+
+            deleteCareCategoryIfEmptyCare(category);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void updateCareDates(Long careId, CareSaveReq.CareInfoDto requestCare) {
+        // careDates 갱신 여부
+        // request.care().careDates() -> 기존 careDates와 비교하여 추가, 삭제, 수정
+        // week, time이 같은 careDate가 존재하면 유지
+        // 같은 week, time이 다르면 수정 후 오늘 자 로그 있으면 삭제
+        // 기존 week가 없으면 추가
+        Map<WeekType, Map<LocalTime, CareDate>> currentCareDatesMap = new HashMap<>();
+        List<CareDate> currentCareDates = careSearchService.findCareDatesFromCareId(careId);
+        for (CareDate currentCareDate : currentCareDates) {
+            currentCareDatesMap.computeIfAbsent(currentCareDate.getWeek(), k -> new HashMap<>()).put(currentCareDate.getCareTime(), currentCareDate);
+        }
+
+        List<CareDate> requestCareDates = requestCare.toCareDateEntity();
+        List<CareDate> newCareDates = new ArrayList<>();
+        for (CareDate requestCareDate : requestCareDates) {
+            Map<LocalTime, CareDate> weekTypeMap = currentCareDatesMap.getOrDefault(requestCareDate.getWeek(), new HashMap<>());
+            CareDate currentCareDate = weekTypeMap.get(requestCareDate.getCareTime());
+
+            if (currentCareDate == null) {
+                newCareDates.add(requestCareDate);
+            } else if (!currentCareDate.getCareTime().equals(requestCareDate.getCareTime())) {
+                currentCareDate.updateCareTime(requestCareDate.getCareTime());
+                if (careLogSearchService.existsByCareDateIdOnLogDate(currentCareDate.getId(), LocalDateTime.now())) {
+                    CareLog careLog = careLogSearchService.findByCareDateIdOnLogDate(currentCareDate.getId(), LocalDateTime.now());
+                    careLogSaveService.delete(careLog);
+                }
+            }
+
+            weekTypeMap.remove(requestCareDate.getCareTime());
+        }
+        careSaveService.saveCareDates(newCareDates);
+
+        List<CareDate> deleteCareDates = currentCareDatesMap.values().stream()
+                .flatMap(map -> map.values().stream())
+                .toList();
+        careSaveService.deleteCareDates(deleteCareDates);
+    }
+
+    @Transactional
+    public CareLog doCare(Long careDateId) throws GlobalErrorException {
+        CareDate careDate = careSearchService.findCareDateById(careDateId);
+        LocalDateTime today = LocalDateTime.now();
+
+        validateTodayRequest(careDate.getWeek(), today);
+
+        if (careLogSearchService.existsByCareDateIdOnLogDate(careDate.getId(), today)) {
+            log.warn("이미 케어를 수행한 기록이 존재합니다.");
+            throw new GlobalErrorException(CareErrorCode.ALREADY_CARED);
+        }
+
+        return careLogSaveService.save(CareLog.of(careDate));
+    }
+
+    @Transactional
+    public void cancelCare(Long careDateId) throws GlobalErrorException {
+        CareDate careDate = careSearchService.findCareDateById(careDateId);
+        LocalDateTime today = LocalDateTime.now();
+
+        validateTodayRequest(careDate.getWeek(), today);
+
+        CareLog careLog = careLogSearchService.findByCareDateIdOnLogDate(careDateId, today);
+        careLogSaveService.delete(careLog);
+    }
+
+    private void validateTodayRequest(WeekType weekType, LocalDateTime today) throws GlobalErrorException {
+        if (!weekType.checkToday()) {
+            log.warn("오늘 날짜에 대한 요청이 아닙니다. {} <- 요청 : {}", WeekType.fromLegacyType(today.getDayOfWeek().toString()), LocalDateTime.now().getDayOfWeek());
+            throw new GlobalErrorException(CareErrorCode.NOT_TODAY_CARE);
+        }
+    }
+
+    @Transactional
+    public void deleteCare(Care care) {
+        CareCategory careCategory = care.getCareCategory();
+        careSaveService.deleteCare(care);
+        deleteCareCategoryIfEmptyCare(careCategory);
+    }
+
+    private void deleteCareCategoryIfEmptyCare(CareCategory careCategory) {
+        if (!careSearchService.existsCareUnderCategory(careCategory.getId())) {
+            careSaveService.deleteCareCategory(careCategory);
+        }
+    }
+}

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/mapper/CareMapper.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/mapper/CareMapper.java
@@ -127,7 +127,7 @@ public class CareMapper {
         deleteCareCategoryIfEmptyCare(category);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public void updateCareDates(Care care, List<CareSaveReq.CareDateDto> requestCareDates) {
         Map<WeekType, Map<LocalTime, CareDate>> currentCareDatesMap = new HashMap<>();
         List<CareDate> currentCareDates = careSearchService.findCareDatesFromCareId(care.getId());

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/mapper/CareMapper.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/mapper/CareMapper.java
@@ -69,9 +69,6 @@ public class CareMapper {
                 continue;
             }
 
-            if (categoryDto.categoryName().isBlank())
-                throw new GlobalErrorException(CareErrorCode.CATEGORY_NAME_IS_BLANK);
-
             Pet pet = petSearchService.findPetById(additionalPetDto.petId());
             CareCategory category = categoryDto.toCareCategory();
             category.updatePet(pet);

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/usecase/CareUseCase.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/usecase/CareUseCase.java
@@ -1,26 +1,19 @@
 package kr.co.fitapet.api.apis.care.usecase;
 
 
+import kr.co.fitapet.api.apis.care.mapper.CareMapper;
 import kr.co.fitapet.common.annotation.UseCase;
 import kr.co.fitapet.common.execption.GlobalErrorException;
 import kr.co.fitapet.domain.domains.care.domain.Care;
 import kr.co.fitapet.domain.domains.care.domain.CareCategory;
-import kr.co.fitapet.domain.domains.care.domain.CareDate;
-import kr.co.fitapet.domain.domains.care.dto.CareCategoryInfo;
-import kr.co.fitapet.domain.domains.care.dto.CareInfoRes;
-import kr.co.fitapet.domain.domains.care.dto.CareSaveReq;
-import kr.co.fitapet.domain.domains.care.exception.CareErrorCode;
+import kr.co.fitapet.api.apis.care.dto.CareCategoryInfo;
+import kr.co.fitapet.api.apis.care.dto.CareInfoRes;
+import kr.co.fitapet.api.apis.care.dto.CareSaveReq;
 import kr.co.fitapet.domain.domains.care.service.CareSearchService;
-import kr.co.fitapet.domain.domains.care.service.CareSaveService;
-import kr.co.fitapet.domain.domains.care.type.WeekType;
 import kr.co.fitapet.domain.domains.care_log.domain.CareLog;
 import kr.co.fitapet.domain.domains.care_log.dto.CareLogInfo;
-import kr.co.fitapet.domain.domains.care_log.exception.CareLogErrorCode;
-import kr.co.fitapet.domain.domains.care_log.service.CareLogSearchService;
-import kr.co.fitapet.domain.domains.care_log.service.CareLogSaveService;
 import kr.co.fitapet.domain.domains.manager.service.ManagerSearchService;
 import kr.co.fitapet.domain.domains.member.service.MemberSearchService;
-import kr.co.fitapet.domain.domains.pet.domain.Pet;
 import kr.co.fitapet.domain.domains.pet.exception.PetErrorCode;
 import kr.co.fitapet.domain.domains.pet.service.PetSearchService;
 import lombok.RequiredArgsConstructor;
@@ -28,26 +21,21 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @UseCase
 @RequiredArgsConstructor
 @Slf4j
 public class CareUseCase {
-    private final CareSaveService careSaveService;
-
     private final MemberSearchService memberSearchService;
     private final ManagerSearchService managerSearchService;
     private final PetSearchService petSearchService;
     private final CareSearchService careSearchService;
-    private final CareLogSearchService careLogSearchService;
-    private final CareLogSaveService careLogSaveService;
+
+    private final CareMapper careMapper;
 
     @Transactional
     public void saveCare(Long userId, Long petId, CareSaveReq.Request request) {
-        CareSaveReq.CategoryDto categoryDto = request.category();
-        CareSaveReq.CareInfoDto careInfoDto = request.care();
         List<CareSaveReq.AdditionalPetDto> additionalPetDtos = request.pets();
 
         List<Long> petIds = additionalPetDtos.stream().map(CareSaveReq.AdditionalPetDto::petId).toList();
@@ -56,144 +44,53 @@ public class CareUseCase {
         }
 
         if (!petIds.contains(petId))
-            additionalPetDtos.add(CareSaveReq.AdditionalPetDto.of(petId, categoryDto.categoryId()));
+            additionalPetDtos.add(CareSaveReq.AdditionalPetDto.of(petId, request.category().categoryId()));
         petSearchService.findPetsByIds(petIds);
 
-        persistAboutCare(categoryDto, careInfoDto, additionalPetDtos);
+        careMapper.saveCare(request.category(), request.care(), additionalPetDtos);
     }
 
     @Transactional
     public List<?> findCareCategoryNamesByPetId(Long petId) {
-         List<CareCategory> careCategories = careSearchService.findAllCareCategoriesByPetId(petId);
+         List<CareCategory> careCategories = careSearchService.findCareCategoriesByPetId(petId);
          return CareCategoryInfo.from(careCategories).getCareCategorySummaries();
     }
 
     @Transactional(readOnly = true)
     public CareInfoRes findCaresByPetId(Long petId) {
-        List<CareCategory> careCategories = careSearchService.findAllCareCategoriesByPetId(petId);
-        List<CareInfoRes.CareCategoryDto> careCategoryDtos = new ArrayList<>();
+        List<CareCategory> careCategories = careSearchService.findCareCategoriesByPetId(petId);
+        LocalDateTime now = LocalDateTime.now();
 
-        for (CareCategory careCategory : careCategories) {
-            List<Care> cares = careCategory.getCares();
-            List<CareInfoRes.CareDto> careDtos = new ArrayList<>();
+        return CareInfoRes.from(careCategories.stream()
+                .map(careCategory -> careMapper.mapToCareCategoryDto(careCategory, now))
+                .filter(careCategoryDto -> !careCategoryDto.cares().isEmpty())
+                .toList());
+    }
 
-            WeekType todayWeek = WeekType.fromLegacyType(LocalDateTime.now().getDayOfWeek().toString());
-            LocalDateTime today = LocalDateTime.now();
+    @Transactional
+    public void updateCare(Long careId, CareSaveReq.UpdateRequest request) {
+        Care care = careSearchService.findCareById(careId);
+        care.updateCare(request.care().careName(), request.care().limitTime());
 
-            for (Care care : cares) {
-                List<CareDate> careDates = careSearchService.findCareDatesFromCareIdAndWeek(care.getId(), todayWeek);
-
-                for (CareDate careDate : careDates) {
-                    boolean isClear = careLogSearchService.existsByCareDateIdOnLogDate(careDate.getId(), today);
-                    careDtos.add(CareInfoRes.CareDto.of(care.getId(), careDate.getId(), care.getCareName(), careDate.getCareTime(), isClear));
-                }
-            }
-            if (!careDtos.isEmpty())
-                careCategoryDtos.add(CareInfoRes.CareCategoryDto.of(careCategory.getId(), careCategory.getCategoryName(), careDtos));
-        }
-        return CareInfoRes.from(careCategoryDtos);
+        CareCategory category = care.getCareCategory();
+        careMapper.updateCareCategory(care, category, request.category());
+        careMapper.updateCareDates(careId, request.care());
     }
 
     @Transactional
     public CareLogInfo doCare(Long userId, Long careDateId) {
-        CareDate careDate = careSearchService.findCareDateById(careDateId);
-
-        if (!careDate.getWeek().checkToday()) {
-            log.warn("오늘 날짜에 대한 요청이 아닙니다. {} <- 요청 : {}", careDate.getWeek(), LocalDateTime.now().getDayOfWeek());
-            throw new GlobalErrorException(CareErrorCode.NOT_TODAY_CARE);
-        }
-
-        LocalDateTime today = LocalDateTime.now();
-        if (careLogSearchService.existsByCareDateIdOnLogDate(careDateId, today)) {
-            log.warn("이미 케어를 수행한 기록이 존재합니다.");
-            throw new GlobalErrorException(CareErrorCode.ALREADY_CARED);
-        }
-
-        CareLog careLog = careLogSaveService.save(CareLog.of(careDate));
-        log.info("careLog: {}", careLog);
+        CareLog careLog = careMapper.doCare(careDateId);
         return CareLogInfo.of(careLog.getLogDate(), memberSearchService.findById(userId).getUid());
     }
 
     @Transactional
     public void cancelCare(Long careDateId) {
-        CareDate careDate = careSearchService.findCareDateById(careDateId);
-        LocalDateTime today = LocalDateTime.now();
-
-        if (!careDate.getWeek().checkToday()) {
-            log.warn("오늘 날짜에 대한 요청이 아닙니다. {} <- 요청 : {}", careDate.getWeek(), LocalDateTime.now().getDayOfWeek());
-            throw new GlobalErrorException(CareErrorCode.NOT_TODAY_CARE);
-        }
-
-        CareLog careLog = careLogSearchService.findByCareDateIdOnLogDate(careDateId, today);
-        careLogSaveService.delete(careLog);
+        careMapper.cancelCare(careDateId);
     }
 
     @Transactional
     public void deleteCare(Long careId) {
         Care care = careSearchService.findCareById(careId);
-        CareCategory careCategory = care.getCareCategory();
-
-        careSaveService.deleteCare(care);
-
-        if (!careSearchService.existsCareUnderCategory(careCategory.getId())) {
-            careSaveService.deleteCareCategory(careCategory);
-        }
-    }
-
-    private void persistAboutCare(
-            CareSaveReq.CategoryDto categoryDto,
-            CareSaveReq.CareInfoDto careInfoDto,
-            List<CareSaveReq.AdditionalPetDto> additionalPetDtos
-    ) {
-        List<CareCategory> categories = findOrCreateCategories(categoryDto, additionalPetDtos);
-        careSaveService.saveCareCategories(categories);
-
-        List<Care> cares = createCares(categoryDto, careInfoDto, categories);
-        careSaveService.saveCares(cares);
-
-        List<CareDate> dates = createCareDates(careInfoDto, cares);
-        careSaveService.saveCareDates(dates);
-    }
-
-    private List<CareCategory> findOrCreateCategories(
-            CareSaveReq.CategoryDto categoryDto,
-            List<CareSaveReq.AdditionalPetDto> additionalPetDtos
-    ) {
-        List<CareCategory> categories = new ArrayList<>(careSearchService.findAllCareCategoriesById(
-                additionalPetDtos.stream().map(CareSaveReq.AdditionalPetDto::categoryId)
-                        .filter(id -> !id.equals(0L)).toList()));
-
-        additionalPetDtos.stream()
-                .filter(dto -> dto.categoryId() == 0L)
-                .map(dto -> {
-                    Pet pet = petSearchService.findPetById(dto.petId());
-                    CareCategory category = categoryDto.toCareCategory();
-                    category.updatePet(pet);
-                    return category;
-                })
-                .forEach(categories::add);
-
-        return categories;
-    }
-
-    private List<Care> createCares(
-            CareSaveReq.CategoryDto categoryDto,
-            CareSaveReq.CareInfoDto careInfoDto,
-            List<CareCategory> categories
-    ) {
-        return categories.stream()
-                .map(category -> {
-                    Care care = careInfoDto.toCare(category);
-                    care.updateCareCategory(category);
-                    return care;
-                })
-                .toList();
-    }
-
-    private List<CareDate> createCareDates(CareSaveReq.CareInfoDto careInfoDto, List<Care> cares) {
-        return cares.stream()
-                .flatMap(care -> careInfoDto.toCareDateEntity().stream()
-                            .peek(date -> date.updateCare(care)))
-                .toList();
+        careMapper.deleteCare(care);
     }
 }

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/usecase/CareUseCase.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/usecase/CareUseCase.java
@@ -95,7 +95,7 @@ public class CareUseCase {
     }
 
     @Transactional
-    public CareLogInfo doCare(Long careDateId, Long userId) {
+    public CareLogInfo doCare(Long userId, Long careDateId) {
         CareDate careDate = careSearchService.findCareDateById(careDateId);
 
         if (!careDate.getWeek().checkToday()) {
@@ -126,6 +126,18 @@ public class CareUseCase {
 
         CareLog careLog = careLogSearchService.findByCareDateIdOnLogDate(careDateId, today);
         careLogSaveService.delete(careLog);
+    }
+
+    @Transactional
+    public void deleteCare(Long careId) {
+        Care care = careSearchService.findCareById(careId);
+        CareCategory careCategory = care.getCareCategory();
+
+        careSaveService.deleteCare(care);
+
+        if (!careSearchService.existsCareUnderCategory(careCategory.getId())) {
+            careSaveService.deleteCareCategory(careCategory);
+        }
     }
 
     private void persistAboutCare(

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/usecase/CareUseCase.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/usecase/CareUseCase.java
@@ -72,9 +72,8 @@ public class CareUseCase {
         Care care = careSearchService.findCareById(careId);
         care.updateCare(request.care().careName(), request.care().limitTime());
 
-        CareCategory category = care.getCareCategory();
-        careMapper.updateCareCategory(care, category, request.category());
-        careMapper.updateCareDates(careId, request.care());
+        careMapper.updateCareCategory(care, request.category());
+        careMapper.updateCareDates(care, request.care().careDates());
     }
 
     @Transactional

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/usecase/CareUseCase.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/care/usecase/CareUseCase.java
@@ -67,6 +67,13 @@ public class CareUseCase {
                 .toList());
     }
 
+    @Transactional(readOnly = true)
+    public List<?> findCareDates(Long careId) {
+        return careSearchService.findCareDatesFromCareId(careId).stream()
+                .map(CareInfoRes.CareDateDto::fromEntity)
+                .toList();
+    }
+
     @Transactional
     public void updateCare(Long careId, CareSaveReq.UpdateRequest request) {
         Care care = careSearchService.findCareById(careId);

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/controller/PetApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/controller/PetApi.java
@@ -14,7 +14,7 @@ import kr.co.fitapet.api.common.response.ErrorResponse;
 import kr.co.fitapet.api.common.response.FailureResponse;
 import kr.co.fitapet.api.common.response.SuccessResponse;
 import kr.co.fitapet.api.common.security.authentication.CustomUserDetails;
-import kr.co.fitapet.domain.domains.care.dto.CareCategoryInfo;
+import kr.co.fitapet.api.apis.care.dto.CareCategoryInfo;
 import kr.co.fitapet.domain.domains.pet.dto.PetInfoRes;
 import kr.co.fitapet.domain.domains.pet.dto.PetSaveReq;
 import lombok.RequiredArgsConstructor;

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/helper/PetCareHelper.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/helper/PetCareHelper.java
@@ -1,0 +1,33 @@
+package kr.co.fitapet.api.apis.pet.helper;
+
+import kr.co.fitapet.common.annotation.Helper;
+import kr.co.fitapet.domain.domains.care.domain.CareCategory;
+import kr.co.fitapet.api.apis.care.dto.CareCategoryInfo;
+import kr.co.fitapet.domain.domains.care.service.CareSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Helper
+@RequiredArgsConstructor
+public class PetCareHelper {
+    private final CareSearchService careSearchService;
+
+    @Transactional(readOnly = true)
+    public List<?> checkCategoryExist(String categoryName, List<Long> petIds) {
+        CareCategoryInfo dto = new CareCategoryInfo();
+
+        for (Long petId : petIds) {
+            List<CareCategory> careCategories = careSearchService.findCareCategoriesByPetId(petId);
+            for (CareCategory careCategory : careCategories) {
+                if (careCategory.getCategoryName().equals(categoryName)) {
+                    dto.addCareCategoryExist(petId, careCategory.getId());
+                    break;
+                }
+            }
+        }
+
+        return dto.getCareCategoryExists();
+    }
+}

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/usecase/PetUseCase.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/usecase/PetUseCase.java
@@ -1,5 +1,6 @@
 package kr.co.fitapet.api.apis.pet.usecase;
 
+import kr.co.fitapet.api.apis.pet.helper.PetCareHelper;
 import kr.co.fitapet.api.apis.pet.mapper.PetManagerMapper;
 import kr.co.fitapet.api.common.security.jwt.exception.AuthErrorCode;
 import kr.co.fitapet.api.common.security.jwt.exception.AuthErrorException;
@@ -19,7 +20,7 @@ import java.util.List;
 public class PetUseCase {
     private final PetManagerMapper petManagerMapper;
     private final PetSaveService petSaveService;
-    private final CareSearchService careSearchService;
+    private final PetCareHelper petCareHelper;
 
     @Transactional
     public void savePet(Pet pet, Long memberId) {
@@ -40,7 +41,7 @@ public class PetUseCase {
         if (!petManagerMapper.isManagerAll(userId, petIds))
             throw new AuthErrorException(AuthErrorCode.FORBIDDEN_ACCESS_TOKEN, "관리자 권한이 없습니다.");
 
-        return careSearchService.checkCategoryExist(categoryName, petIds);
+        return petCareHelper.checkCategoryExist(categoryName, petIds);
     }
 
     @Transactional(readOnly = true)

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/controller/AccountApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/controller/AccountApi.java
@@ -80,7 +80,7 @@ public class AccountApi {
             @RequestParam("type") MemberAttrType type,
             @RequestBody @Valid ProfilePatchReq req
     ) {
-        log.info("type: {}", type);
+        log.info("id: {}, type: {}", id, type);
         memberAccountUseCase.updateProfile(id, req, type);
 
         return ResponseEntity.ok(SuccessResponse.noContent());

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/dto/ProfilePatchReq.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/dto/ProfilePatchReq.java
@@ -10,15 +10,12 @@ import javax.naming.OperationNotSupportedException;
 @Schema(description = "회원 프로필 수정 요청")
 public class ProfilePatchReq {
     @Schema(description = "이름")
-    @NotEmpty
     @Getter
     private String name;
     @Schema(description = "현재 비밀번호")
-    @NotEmpty
     @Getter
     private String prePassword;
     @Schema(description = "갱신 비밀번호")
-    @NotEmpty
     private String newPassword;
 
     public String getNewEncodedPassword(PasswordEncoder passwordEncoder) {

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/domain/Care.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/domain/Care.java
@@ -31,7 +31,7 @@ public class Care extends AuthorAuditable {
     private Care(String careName, Integer limitTime, CareCategory careCategory) {
         this.careName = careName;
         this.limitTime = limitTime;
-        this.careCategory = careCategory;
+        updateCareCategory(careCategory);
     }
 
     public static Care of(String careName, Integer limitTime, CareCategory careCategory) {
@@ -40,6 +40,11 @@ public class Care extends AuthorAuditable {
                 .limitTime(limitTime)
                 .careCategory(careCategory)
                 .build();
+    }
+
+    public void updateCare(String careName, Integer limitTime) {
+        this.careName = careName;
+        this.limitTime = limitTime;
     }
 
     public void updateCareCategory(CareCategory careCategory) {

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/domain/CareDate.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/domain/CareDate.java
@@ -54,6 +54,10 @@ public class CareDate extends DateAuditable {
         return week.checkToday();
     }
 
+    public void updateCareTime(LocalTime careTime) {
+        this.careTime = careTime;
+    }
+
     @Override public String toString() {
         return "CareDetail{" +
                 "id=" + id +

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/domain/CareDate.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/domain/CareDate.java
@@ -30,15 +30,17 @@ public class CareDate extends DateAuditable {
     private List<CareLog> careLogs = new ArrayList<>();
 
     @Builder
-    private CareDate(WeekType week, LocalTime careTime) {
+    private CareDate(WeekType week, LocalTime careTime, Care care) {
         this.week = week;
         this.careTime = careTime;
+        updateCare(care);
     }
 
-    public static CareDate of(WeekType week, LocalTime careTime) {
+    public static CareDate of(WeekType week, LocalTime careTime, Care care) {
         return CareDate.builder()
                 .week(week)
                 .careTime(careTime)
+                .care(care)
                 .build();
     }
 

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/exception/CareErrorCode.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/exception/CareErrorCode.java
@@ -15,6 +15,7 @@ public enum CareErrorCode implements BaseErrorCode {
     CATEGORY_STATUS_INVALID(BAD_REQUEST.getCode(), "카테고리를 생성할 수 없는 상태입니다."),
     ALREADY_CARED(BAD_REQUEST.getCode(), "이미 케어한 날짜에 대한 요청"),
     NOT_TODAY_CARE(BAD_REQUEST.getCode(), "오늘 날짜에 대한 요청이 아님"),
+    CATEGORY_NAME_IS_BLANK(BAD_REQUEST.getCode(), "카테고리 이름은 공백을 제외한 문자열이어야 합니다.")
 
     ;
 

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/repository/CareDateRepository.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/repository/CareDateRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 
 public interface CareDateRepository extends ExtendedRepository<CareDate, Long> {
     List<CareDate> findAllByCare_IdAndWeek(Long careId, WeekType week);
+    List<CareDate> findAllByCare_Id(Long careId);
     boolean existsByIdAndCare_Id(Long careDateId, Long careId);
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/repository/CareRepository.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/repository/CareRepository.java
@@ -5,5 +5,5 @@ import kr.co.fitapet.domain.common.repository.ExtendedRepository;
 import kr.co.fitapet.domain.domains.care.domain.Care;
 
 public interface CareRepository extends ExtendedRepository<Care, Long>, CareQueryDslRepository {
-
+    boolean existsByCareCategory_Id(Long categoryId);
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/service/CareSaveService.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/service/CareSaveService.java
@@ -47,11 +47,6 @@ public class CareSaveService {
     }
 
     @Transactional
-    public void saveCareDateList(List<CareDate> careDateList) {
-        careDateRepository.saveAll(careDateList);
-    }
-
-    @Transactional
     public CareCategory saveCareCategory(CareCategory careCategory) {
         return careCategoryRepository.save(careCategory);
     }
@@ -64,5 +59,10 @@ public class CareSaveService {
     @Transactional
     public void deleteCareCategory(CareCategory careCategory) {
         careCategoryRepository.delete(careCategory);
+    }
+
+    @Transactional
+    public void deleteCareDates(List<CareDate> careDates) {
+        careDateRepository.deleteAll(careDates);
     }
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/service/CareSaveService.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/service/CareSaveService.java
@@ -10,14 +10,13 @@ import kr.co.fitapet.domain.domains.care.repository.CareDateRepository;
 import kr.co.fitapet.domain.domains.care.repository.CareRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @DomainService
 @RequiredArgsConstructor
 @Slf4j
-public class CareUpdateService {
+public class CareSaveService {
     private final CareRepository careRepository;
     private final CareDateRepository careDateRepository;
     private final CareCategoryRepository careCategoryRepository;

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/service/CareSaveService.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/service/CareSaveService.java
@@ -55,4 +55,14 @@ public class CareSaveService {
     public CareCategory saveCareCategory(CareCategory careCategory) {
         return careCategoryRepository.save(careCategory);
     }
+
+    @Transactional
+    public void deleteCare(Care care) {
+        careRepository.delete(care);
+    }
+
+    @Transactional
+    public void deleteCareCategory(CareCategory careCategory) {
+        careCategoryRepository.delete(careCategory);
+    }
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/service/CareSearchService.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/service/CareSearchService.java
@@ -4,7 +4,6 @@ import kr.co.fitapet.common.annotation.DomainService;
 import kr.co.fitapet.domain.domains.care.domain.Care;
 import kr.co.fitapet.domain.domains.care.domain.CareCategory;
 import kr.co.fitapet.domain.domains.care.domain.CareDate;
-import kr.co.fitapet.domain.domains.care.dto.CareCategoryInfo;
 import kr.co.fitapet.domain.domains.care.repository.CareCategoryRepository;
 import kr.co.fitapet.domain.domains.care.repository.CareDateRepository;
 import kr.co.fitapet.domain.domains.care.repository.CareRepository;
@@ -32,6 +31,11 @@ public class CareSearchService {
     }
 
     @Transactional(readOnly = true)
+    public List<CareDate> findCareDatesFromCareId(Long careId) {
+        return careDateRepository.findAllByCare_Id(careId);
+    }
+
+    @Transactional(readOnly = true)
     public List<CareDate> findCareDatesFromCareIdAndWeek(Long careId, WeekType week) {
         return careDateRepository.findAllByCare_IdAndWeek(careId, week);
     }
@@ -42,30 +46,13 @@ public class CareSearchService {
     }
 
     @Transactional(readOnly = true)
-    public List<CareCategory> findAllCareCategoriesById(List<Long> categoryIds) {
+    public List<CareCategory> findCareCategoriesByIds(List<Long> categoryIds) {
         return careCategoryRepository.findAllById(categoryIds);
     }
 
     @Transactional(readOnly = true)
-    public List<CareCategory> findAllCareCategoriesByPetId(Long petId) {
+    public List<CareCategory> findCareCategoriesByPetId(Long petId) {
         return careCategoryRepository.findAllByPet_Id(petId);
-    }
-
-    @Transactional(readOnly = true)
-    public List<?> checkCategoryExist(String categoryName, List<Long> petIds) {
-        CareCategoryInfo dto = new CareCategoryInfo();
-
-        for (Long petId : petIds) {
-            List<CareCategory> careCategories = careCategoryRepository.findAllByPet_Id(petId);
-            for (CareCategory careCategory : careCategories) {
-                if (careCategory.getCategoryName().equals(categoryName)) {
-                    dto.addCareCategoryExist(petId, careCategory.getId());
-                    break;
-                }
-            }
-        }
-
-        return dto.getCareCategoryExists();
     }
 
     @Transactional(readOnly = true)

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/service/CareSearchService.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care/service/CareSearchService.java
@@ -67,4 +67,9 @@ public class CareSearchService {
 
         return dto.getCareCategoryExists();
     }
+
+    @Transactional(readOnly = true)
+    public boolean existsCareUnderCategory(Long categoryId) {
+        return careRepository.existsByCareCategory_Id(categoryId);
+    }
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care_log/exception/CareLogErrorCode.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care_log/exception/CareLogErrorCode.java
@@ -1,22 +1,17 @@
-package kr.co.fitapet.domain.domains.care.exception;
+package kr.co.fitapet.domain.domains.care_log.exception;
 
 import kr.co.fitapet.common.execption.BaseErrorCode;
 import kr.co.fitapet.common.execption.CausedBy;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import static kr.co.fitapet.common.execption.StatusCode.BAD_REQUEST;
 import static kr.co.fitapet.common.execption.StatusCode.NOT_FOUND;
 
 @Getter
 @RequiredArgsConstructor
-public enum CareErrorCode implements BaseErrorCode {
-    /* 400 BAD_REQUEST */
-    CATEGORY_STATUS_INVALID(BAD_REQUEST.getCode(), "카테고리를 생성할 수 없는 상태입니다."),
-    ALREADY_CARED(BAD_REQUEST.getCode(), "이미 케어한 날짜에 대한 요청"),
-    NOT_TODAY_CARE(BAD_REQUEST.getCode(), "오늘 날짜에 대한 요청이 아님"),
-
-    ;
+public enum CareLogErrorCode implements BaseErrorCode {
+    /* 404 NOT_FOUND */
+    NOT_FOUND_CARE_LOG(NOT_FOUND.getCode(), "케어 로그를 찾을 수 없음");
 
     private final int code;
     private final String message;

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care_log/repository/CareLogQueryRepository.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care_log/repository/CareLogQueryRepository.java
@@ -1,7 +1,11 @@
 package kr.co.fitapet.domain.domains.care_log.repository;
 
+import kr.co.fitapet.domain.domains.care_log.domain.CareLog;
+
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface CareLogQueryRepository {
     boolean existsByCareDateIdAndLogDate(Long careDateId, LocalDateTime logDate);
+    Optional<CareLog> findByCareDateIdAndLogDate(Long careDateId, LocalDateTime logDate);
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care_log/repository/CareLogQueryRepositoryImpl.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care_log/repository/CareLogQueryRepositoryImpl.java
@@ -2,12 +2,14 @@ package kr.co.fitapet.domain.domains.care_log.repository;
 
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.fitapet.domain.domains.care_log.domain.CareLog;
 import kr.co.fitapet.domain.domains.care_log.domain.QCareLog;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -26,6 +28,18 @@ public class CareLogQueryRepositoryImpl implements CareLogQueryRepository {
                         ))
                         )
                 .fetchFirst() != null;
+    }
+
+    @Override
+    public Optional<CareLog> findByCareDateIdAndLogDate(Long careDateId, LocalDateTime logDate) {
+        return Optional.ofNullable(queryFactory.selectFrom(careLog)
+                .where(careLog.careDate.id.eq(careDateId)
+                        .and(careLog.logDate.between(
+                            Expressions.asDateTime(logDate.withHour(0).withMinute(0).withSecond(0)),
+                            Expressions.asDateTime(logDate.withHour(23).withMinute(59).withSecond(59))
+                        ))
+                        )
+                .fetchFirst());
     }
 
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care_log/service/CareLogSaveService.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care_log/service/CareLogSaveService.java
@@ -4,13 +4,20 @@ import kr.co.fitapet.common.annotation.DomainService;
 import kr.co.fitapet.domain.domains.care_log.domain.CareLog;
 import kr.co.fitapet.domain.domains.care_log.repository.CareLogRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @DomainService
 @RequiredArgsConstructor
-public class CareLogUpdateService {
+public class CareLogSaveService {
     private final CareLogRepository careLogRepository;
 
+    @Transactional
     public CareLog save(CareLog careLog) {
         return careLogRepository.save(careLog);
+    }
+
+    @Transactional
+    public void delete(CareLog careLog) {
+        careLogRepository.delete(careLog);
     }
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care_log/service/CareLogSearchService.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/care_log/service/CareLogSearchService.java
@@ -1,6 +1,9 @@
 package kr.co.fitapet.domain.domains.care_log.service;
 
 import kr.co.fitapet.common.annotation.DomainService;
+import kr.co.fitapet.common.execption.GlobalErrorException;
+import kr.co.fitapet.domain.domains.care_log.domain.CareLog;
+import kr.co.fitapet.domain.domains.care_log.exception.CareLogErrorCode;
 import kr.co.fitapet.domain.domains.care_log.repository.CareLogQueryRepository;
 import kr.co.fitapet.domain.domains.care_log.repository.CareLogRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +21,12 @@ public class CareLogSearchService {
     @Transactional(readOnly = true)
     public boolean existsByCareDateIdOnLogDate(Long careDateId, LocalDateTime date) {
         return careLogQueryRepository.existsByCareDateIdAndLogDate(careDateId, date);
+    }
+
+    @Transactional(readOnly = true)
+    public CareLog findByCareDateIdOnLogDate(Long careDateId, LocalDateTime date) {
+        return careLogQueryRepository.findByCareDateIdAndLogDate(careDateId, date).orElseThrow(
+                () -> new GlobalErrorException(CareLogErrorCode.NOT_FOUND_CARE_LOG)
+        );
     }
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/member/type/MemberAttrType.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/member/type/MemberAttrType.java
@@ -9,5 +9,4 @@ public enum MemberAttrType {
     NAME("name"), PASSWORD("password");
 
     private final String attr;
-
 }


### PR DESCRIPTION
## 작업 이유
> 104번 이슈인데 114번 브랜치 파서 작업한 나..
- care 수정 및 삭제 관련 api
- care 수정 페이지를 위한 조회 api (작업 중)

## 작업 사항
> ⚠️ 양은 그렇게 안 많은데, 수정 API가 굉장히 복잡합니다.

### 1️⃣ 케어 완료 취소

<div align="center" style="width:50px">
   <img src="https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/8cbbea30-64a5-4663-8642-2a8ee60e7995" width='400'/>
</div>

- 요청: `DELETE /api/v2/pets/{pet_id}/cares/{care_id}/care-dates/{care_date_id}`
  - 오늘 날짜에 대한 요청이 아닌 경우 에러 응답
  - 매칭되는 log가 없을 경우 에러 응답

<br/>

### 2️⃣ 케어 조회 (수정용)

<div align="center" style="width:50px">
   <img src="https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/adc0aa82-f7f0-4ff6-9d5e-cd9cf2d61e0f" width='300'/>
</div>
- 가정
  - client 측에서 수정하려는 `care`와 `careCategory` 정보를 판단할 수 있다.
  - server 측은 `careId`에 해당하는 `careDates` 정보만 반환하면 된다.

- 요청: `GET /api/v2/pets/{pet_id}/cares/{care_id}/care-dates`
- 응답
   ```json
   {
    "status": "success",
    "data": {
        "careDates": [ // 반드시 배열 형태로 반환.
            {
                "careDateId": 1, // id 정보
                "week": "토", // 요일 정보
                "time": "12:00:00" // 시간 정보
            },
            ...
   }
   ```

**🟡 응답 예시**

<div align="center" style="width:50px">
   <img src="https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/f01951a2-b398-4a11-9360-a6158e5347b6" width='300'/>
</div>

<br/>

### 3️⃣ 케어 수정
- 요청: `PUT /api/v2/pets/{pet_id}/cares/{care_id}`
   - [케어 등록 API](https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/pull/70)에서 `pets` 필드가 없는 케이스
   - category
     - `categoryName`은 null 혹은 공백문자(`" "`)를 허용하지 않습니다. 반드시 채워주세요.
     - `categoryId == 0` : 신규 카테고리로 케어 이동
     - `categoryId != 0 && originCategoryId != categoryId` : 다른 카테고리로 이동 (옮길 카테고리는 반드시 `pet_id`에 등록되어 있어야 함)
     - `categoryId != 0 && originCategoryId == categoryId` : 변경 없음
     - category 이동 시, 기존 category 하위에 care 목록이 없다면 category 삭제
   - care
     - `careName`: 수정할 케어명 혹은 기존 케어명 (덮어쓰기)
     - `careDates`: 현재 유저가 정한 설정값 그대로 전달
        - week에 대한 기존 정보 없는 경우 ⇒ 해당 요일 케어 갱신
        - week에 대한 time 정보 불일치 ⇒ 해당 week의 케어 정보를 요청한 time으로 갱신
        - week와 time이 기존 정보와 동일 ⇒ 변경 없음
     - 만약 수행 내역이 존재하는 `careId == 1`에 수정/삭제가 발생하는 경우, 수행 결과는 자동으로 제거됩니다.
   ```json
   {
       "category" : {
            "categoryId" : 0, // (==0: 신규 카테고리 생성, !=0: 기존 category_id와 다르면 변경)
            "categoryName" : "지정할 카테고리명" // 신규 생성에만 유효하지만, 전체 공백 문자나 null을 허용하지 않음
       },
       "care" : {
            "careName" : "수정할 care 이름", 
            "careDates" : [ // 케어 요일 목록(현재 설정 값 그대로 전송)
                 { 
                      "week" : "월",
                      "time" : "12:00:00"
                 },
                 ...
            ],
            "limitTime" : 5 // 분 단위. 없으면 0 
       },
   }
   ```

**🟡 요청 예시1. 새로운 카테고리**

<div align="center" style="width:50px">
   <img src="https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/6189d1ba-3a49-4456-bffc-8856a1ca7009" width='500'/>
</div>


**🟡 요청 예시2. 기존의 다른 카테고리**

<div align="center" style="width:50px">
   <img src="https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/9f8a7ea9-f3ce-43c9-a7fa-82e97ee5abec" width='500'/>
</div>

**🟡 요청 예시3. 카테고리 유지 & 케어 목록 수정**

<div align="center" style="width:50px">
   <img src="https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/b0a8c9eb-3987-4b61-9c16-2b6e0043e376" width='500'/>
</div>

<br/>

### 4️⃣  케어 삭제
- 요청: `DELETE /api/v2/pets/{pet_id}/cares/{care_id}`
   - `care_id`에 해당하는 하위 모든 데이터가 제거됩니다.
   - care가 등록되어 있던 `category`에 하위 카테고리가 존재하지 않는다면, 함께 삭제됩니다.

<br/>

## 이슈 연결
close #104 