### PR TITLE
✨ 반려동물 수정/삭제 API 및 사용자 설정 이름 반환 API

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,6 +46,7 @@ jobs:
       - name: docker image build & push
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          cat ${{ secrets.IOS_FIREBASE_ADMINSDK }} > fitapet-app-external-api/src/main/resources/fitapet-ios-firebase-adminsdk-ethnn-6ec10fe329.json
           docker build -t ${{ secrets.DOCKER_NICKNAME }}/fitapet:latest .
           docker push ${{ secrets.DOCKER_NICKNAME }}/fitapet:latest  
 

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/notification/controller/NotificationApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/notification/controller/NotificationApi.java
@@ -1,0 +1,15 @@
+package kr.co.fitapet.api.apis.notification.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "알림 API")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/notifications")
+public class NotificationApi {
+}

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/notification/usecase/NotificationUseCase.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/notification/usecase/NotificationUseCase.java
@@ -1,0 +1,11 @@
+package kr.co.fitapet.api.apis.notification.usecase;
+
+import kr.co.fitapet.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class NotificationUseCase {
+}

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/controller/PetApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/controller/PetApi.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 @Tag(name = "반려동물 관리 API")
 @RestController
-@RequestMapping("/api/v2/users/{user_id}/pets")
+@RequestMapping("/api/v2/pets")
 @RequiredArgsConstructor
 @Slf4j
 public class PetApi {
@@ -51,27 +51,36 @@ public class PetApi {
 
     @Operation(summary = "관리 중인 반려동물 리스트 조회")
     @GetMapping("")
-    @PreAuthorize("isAuthenticated() and #userId == principal.userId")
-    public ResponseEntity<?> getPets(@PathVariable("user_id") Long userId) {
-        PetInfoRes pets = petUseCase.getPets(userId);
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getPets(@AuthenticationPrincipal CustomUserDetails user) {
+        PetInfoRes pets = petUseCase.getPets(user.getUserId());
         return ResponseEntity.ok(SuccessResponse.from("pets", pets.getPets()));
     }
 
-    @Operation(summary = "관리 중인 반려동물 목록 조회")
-    @Parameter(name = "user_id", description = "조회할 유저 ID", required = true)
+    @Operation(summary = "관리 중인 반려동물 요약 목록 조회")
     @GetMapping("/summary")
-    @PreAuthorize("isAuthenticated() and #userId == principal.userId")
-    public ResponseEntity<?> findPets(@PathVariable("user_id") Long userId) {
-        List<?> pets = petUseCase.findPetsSummaryByUserId(userId).getPets();
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> findPets(@AuthenticationPrincipal CustomUserDetails user) {
+        List<?> pets = petUseCase.findPetsSummaryByUserId(user.getUserId()).getPets();
         return ResponseEntity.ok(SuccessResponse.from("pets", pets));
     }
 
     @Operation(summary = "반려동물 케어 카테고리 유효성 검사")
     @Parameter(name = "user_id", description = "조회할 유저 ID", in = ParameterIn.PATH, required = true)
     @PostMapping("/categories-check")
-    @PreAuthorize("isAuthenticated() and #userId == principal.userId")
-    public ResponseEntity<?> checkCategoryExist(@PathVariable("user_id") Long userId, @RequestBody @Valid CareCategoryInfo.CareCategoryExistRequest request) {
-        List<?> result = petUseCase.checkCategoryExist(userId, request.categoryName(), request.pets());
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> checkCategoryExist(@AuthenticationPrincipal CustomUserDetails user, @RequestBody @Valid CareCategoryInfo.CareCategoryExistRequest request) {
+        List<?> result = petUseCase.checkCategoryExist(user.getUserId(), request.categoryName(), request.pets());
         return ResponseEntity.ok(SuccessResponse.from("categories", result));
     }
+
+    @Operation(summary = "반려동물 삭제")
+    @Parameter(name = "pet_id", description = "삭제할 반려동물 ID", in = ParameterIn.PATH, required = true)
+    @DeleteMapping("/{pet_id}")
+    @PreAuthorize("isAuthenticated() and @managerAuthorize.isMaster(principal.userId, #petId)")
+    public ResponseEntity<?> deletePet(@PathVariable("pet_id") Long petId) {
+        petUseCase.deletePet(petId);
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
+
 }

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/dto/PetDetailRes.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/dto/PetDetailRes.java
@@ -1,0 +1,36 @@
+package kr.co.fitapet.api.apis.pet.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import kr.co.fitapet.domain.domains.pet.domain.Pet;
+import kr.co.fitapet.domain.domains.pet.type.GenderType;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+public record PetDetailRes(
+        Long id,
+        String petName,
+        String petProfileImage,
+        GenderType gender,
+        Boolean neutered,
+        @JsonSerialize(using = LocalDateSerializer.class)
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate birthdate,
+        String species,
+        String feed
+) {
+    public static PetDetailRes from(Pet pet) {
+        return new PetDetailRes(
+                pet.getId(),
+                pet.getPetName(),
+                Objects.toString(pet.getPetProfileImg(), ""),
+                pet.getGender(),
+                pet.isNeutered(),
+                pet.getBirthdate(),
+                pet.getSpecies(),
+                Objects.toString(pet.getFeed(), "")
+        );
+    }
+}

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/mapper/PetImageSearchMapper.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/mapper/PetImageSearchMapper.java
@@ -1,0 +1,37 @@
+package kr.co.fitapet.api.apis.pet.mapper;
+
+import kr.co.fitapet.common.annotation.Mapper;
+import kr.co.fitapet.domain.domains.memo.service.MemoSearchService;
+import kr.co.fitapet.domain.domains.pet.domain.Pet;
+import kr.co.fitapet.domain.domains.pet.service.PetSearchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Mapper
+@RequiredArgsConstructor
+public class PetImageSearchMapper {
+    private final PetSearchService petSearchService;
+    private final MemoSearchService memoSearchService;
+
+    /**
+     * 반려동물 프로필 이미지와 메모에 등록된 모든 이미지 조회
+     */
+    @Transactional(readOnly = true)
+    public List<String> findPetProfileImageAndMemoImageUrls(Long petId) {
+        List<String> images = new ArrayList<>();
+
+        Pet pet = petSearchService.findPetById(petId);
+        if (pet.getPetProfileImg() != null)
+            images.add(pet.getPetProfileImg());
+        List<Long> memoIds = memoSearchService.findMemoIdsByPetId(pet.getId());
+        List<String> memoImageUrls = memoSearchService.findMemoImageUrlsByMemoIds(memoIds);
+        images.addAll(memoImageUrls);
+
+        return images;
+    }
+}

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/usecase/PetUseCase.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/usecase/PetUseCase.java
@@ -1,25 +1,26 @@
 package kr.co.fitapet.api.apis.pet.usecase;
 
+import kr.co.fitapet.api.apis.pet.dto.PetDetailRes;
 import kr.co.fitapet.api.apis.pet.helper.PetCareHelper;
 import kr.co.fitapet.api.apis.pet.mapper.PetImageSearchMapper;
 import kr.co.fitapet.api.apis.pet.mapper.PetManagerMapper;
 import kr.co.fitapet.api.common.security.jwt.exception.AuthErrorCode;
 import kr.co.fitapet.api.common.security.jwt.exception.AuthErrorException;
 import kr.co.fitapet.common.annotation.UseCase;
-import kr.co.fitapet.domain.domains.care.service.CareSearchService;
 import kr.co.fitapet.domain.domains.memo.domain.MemoCategory;
 import kr.co.fitapet.domain.domains.pet.domain.Pet;
 import kr.co.fitapet.domain.domains.pet.dto.PetInfoRes;
+import kr.co.fitapet.domain.domains.pet.dto.PetSaveReq;
 import kr.co.fitapet.domain.domains.pet.service.PetDeleteService;
 import kr.co.fitapet.domain.domains.pet.service.PetSaveService;
 import kr.co.fitapet.domain.domains.pet.service.PetSearchService;
 import kr.co.fitapet.infra.common.event.ObjectStorageImageDeleteEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @UseCase
@@ -29,6 +30,7 @@ public class PetUseCase {
     private final PetManagerMapper petManagerMapper;
     private final PetImageSearchMapper petImageSearchMapper;
 
+    private final PetSearchService petSearchService;
     private final PetSaveService petSaveService;
     private final PetDeleteService petDeleteService;
     private final PetCareHelper petCareHelper;
@@ -58,13 +60,27 @@ public class PetUseCase {
     }
 
     @Transactional(readOnly = true)
-    public PetInfoRes getPets(Long userId) {
+    public PetInfoRes findPets(Long userId) {
         List<Pet> pets = petManagerMapper.findAllManagerByMemberId(userId);
         return PetInfoRes.ofPetInfo(pets);
     }
 
+    @Transactional(readOnly = true)
+    public PetDetailRes findPet(Long petId) {
+        Pet pet = petSearchService.findPetById(petId);
+        return PetDetailRes.from(pet);
+    }
+
     @Transactional
-    public void deletePet(Long petId) {
+    public void updatePet(Long petId, PetSaveReq req) {
+        Pet pet = petSearchService.findPetById(petId);
+        pet.updatePet(req.toEntity());
+        petSaveService.savePet(pet);
+    }
+
+    @Transactional
+    @CacheEvict(value = "master", key = "#masterId + '@' + #petId", cacheManager = "managerCacheManager")
+    public void deletePet(Long petId, Long masterId) {
         log.info("deletePet: {}", petId);
         List<String> deleteImageUrls = petImageSearchMapper.findPetProfileImageAndMemoImageUrls(petId);
         log.info("deleteImageUrls: {}", deleteImageUrls);

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/usecase/PetUseCase.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/pet/usecase/PetUseCase.java
@@ -1,6 +1,7 @@
 package kr.co.fitapet.api.apis.pet.usecase;
 
 import kr.co.fitapet.api.apis.pet.helper.PetCareHelper;
+import kr.co.fitapet.api.apis.pet.mapper.PetImageSearchMapper;
 import kr.co.fitapet.api.apis.pet.mapper.PetManagerMapper;
 import kr.co.fitapet.api.common.security.jwt.exception.AuthErrorCode;
 import kr.co.fitapet.api.common.security.jwt.exception.AuthErrorException;
@@ -9,18 +10,30 @@ import kr.co.fitapet.domain.domains.care.service.CareSearchService;
 import kr.co.fitapet.domain.domains.memo.domain.MemoCategory;
 import kr.co.fitapet.domain.domains.pet.domain.Pet;
 import kr.co.fitapet.domain.domains.pet.dto.PetInfoRes;
+import kr.co.fitapet.domain.domains.pet.service.PetDeleteService;
 import kr.co.fitapet.domain.domains.pet.service.PetSaveService;
+import kr.co.fitapet.domain.domains.pet.service.PetSearchService;
+import kr.co.fitapet.infra.common.event.ObjectStorageImageDeleteEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @UseCase
+@Slf4j
 @RequiredArgsConstructor
 public class PetUseCase {
     private final PetManagerMapper petManagerMapper;
+    private final PetImageSearchMapper petImageSearchMapper;
+
     private final PetSaveService petSaveService;
+    private final PetDeleteService petDeleteService;
     private final PetCareHelper petCareHelper;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void savePet(Pet pet, Long memberId) {
@@ -48,5 +61,14 @@ public class PetUseCase {
     public PetInfoRes getPets(Long userId) {
         List<Pet> pets = petManagerMapper.findAllManagerByMemberId(userId);
         return PetInfoRes.ofPetInfo(pets);
+    }
+
+    @Transactional
+    public void deletePet(Long petId) {
+        log.info("deletePet: {}", petId);
+        List<String> deleteImageUrls = petImageSearchMapper.findPetProfileImageAndMemoImageUrls(petId);
+        log.info("deleteImageUrls: {}", deleteImageUrls);
+        petDeleteService.deletePet(petId);
+        eventPublisher.publishEvent(ObjectStorageImageDeleteEvent.valueOf(deleteImageUrls));
     }
 }

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/controller/AccountApi.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/controller/AccountApi.java
@@ -52,6 +52,14 @@ public class AccountApi {
         return ResponseEntity.ok(SuccessResponse.from(member));
     }
 
+    @Operation(summary = "사용자 설정 이름 조회")
+    @Parameter(name = "id", description = "조회할 프로필 ID", in = ParameterIn.PATH, required = true)
+    @GetMapping("/{id}/name")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getUserName(@PathVariable("id") Long id) {
+        return ResponseEntity.ok(SuccessResponse.from("name", memberAccountUseCase.findUserName(id)));
+    }
+
     @Operation(summary = "디바이스 토큰 등록")
     @PostMapping("/{id}/device-token")
     @PreAuthorize("isAuthenticated() and #id == principal.userId")

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/usecase/MemberAccountUseCase.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/profile/usecase/MemberAccountUseCase.java
@@ -63,6 +63,11 @@ public class MemberAccountUseCase {
         return AccountProfileRes.from(member);
     }
 
+    @Transactional(readOnly = true)
+    public String findUserName(Long userId) {
+        return memberSearchService.findById(userId).getName();
+    }
+
     @Transactional
     public void registerDeviceToken(Long memberId, DeviceTokenReq req) {
         Member member = memberSearchService.findById(memberId);

--- a/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/test/NotificationTestController.java
+++ b/fitapet-app-external-api/src/main/java/kr/co/fitapet/api/apis/test/NotificationTestController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationTestController {
     private final NotificationTestService notificationTestService;
 
-    @RequestMapping("/push")
+    @GetMapping("/push")
     @PreAuthorize("isAuthenticated()")
     public void push(@AuthenticationPrincipal CustomUserDetails user) {
         notificationTestService.push(user.getUserId());

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/common/redis/manager/ManagerInvitationRepositoryImpl.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/common/redis/manager/ManagerInvitationRepositoryImpl.java
@@ -43,4 +43,5 @@ public class ManagerInvitationRepositoryImpl implements ManagerInvitationReposit
     public void delete(String petId, Long invitedId) {
         ops.delete(KEY + ":" + petId, invitedId);
     }
+
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoImageQueryDslRepository.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoImageQueryDslRepository.java
@@ -1,0 +1,7 @@
+package kr.co.fitapet.domain.domains.memo.repository;
+
+import java.util.List;
+
+public interface MemoImageQueryDslRepository {
+    List<String> findMemoImageUrlsByMemoIds(List<Long> memoIds);
+}

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoImageQueryDslRepositoryImpl.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoImageQueryDslRepositoryImpl.java
@@ -1,0 +1,28 @@
+package kr.co.fitapet.domain.domains.memo.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.fitapet.domain.domains.memo.domain.QMemo;
+import kr.co.fitapet.domain.domains.memo.domain.QMemoImage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class MemoImageQueryDslRepositoryImpl implements MemoImageQueryDslRepository {
+    private final JPAQueryFactory queryFactory;
+    private final QMemo memo = QMemo.memo;
+    private final QMemoImage memoImage = QMemoImage.memoImage;
+
+    @Override
+    public List<String> findMemoImageUrlsByMemoIds(List<Long> memoIds) {
+        return queryFactory
+                .select(memoImage.imgUrl)
+                .from(memoImage)
+                .where(memoImage.memo.id.in(memoIds))
+                .fetch();
+    }
+}

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoImageRepository.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoImageRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-public interface MemoImageRepository extends ExtendedRepository<MemoImage, Long> {
+public interface MemoImageRepository extends ExtendedRepository<MemoImage, Long>, MemoImageQueryDslRepository {
     List<MemoImage> findByMemo_Id(Long memoId);
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from MemoImage mi where mi in :memoImages")

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoQueryDslRepository.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoQueryDslRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MemoQueryDslRepository {
+    List<Long> findMemoIdsByPetId(Long petId);
     Optional<MemoInfoDto.MemoInfo> findMemoAndMemoImageUrlsById(Long memoId);
     Slice<MemoInfoDto.MemoSummaryInfo> findMemosInMemoCategory(Long memoCategoryId, Pageable pageable, String target);
     Slice<MemoInfoDto.MemoSummaryInfo> findMemosByPetId(Long petId, Pageable pageable);

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoQueryDslRepositoryImpl.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/repository/MemoQueryDslRepositoryImpl.java
@@ -34,6 +34,17 @@ public class MemoQueryDslRepositoryImpl implements MemoQueryDslRepository {
     private final QMemoCategory memoCategory = QMemoCategory.memoCategory;
 
     @Override
+    public List<Long> findMemoIdsByPetId(Long petId) {
+        return queryFactory
+                .select(memo.id)
+                .from(memoCategory)
+                .leftJoin(memo).on(memo.memoCategory.id.eq(memoCategory.id))
+                .where(memoCategory.pet.id.eq(petId)
+                        .and(memo.id.isNotNull()))
+                .fetch();
+    }
+
+    @Override
     public Optional<MemoInfoDto.MemoInfo> findMemoAndMemoImageUrlsById(Long memoId) {
         List<MemoInfoDto.MemoInfo> result = queryFactory
                 .from(memo)

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/service/MemoSearchService.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/memo/service/MemoSearchService.java
@@ -57,6 +57,11 @@ public class MemoSearchService {
     }
 
     @Transactional(readOnly = true)
+    public List<Long> findMemoIdsByPetId(Long petId) {
+        return memoRepository.findMemoIdsByPetId(petId);
+    }
+
+    @Transactional(readOnly = true)
     public MemoInfoDto.MemoInfo findMemoAndMemoImageUrlsById(Long memoId) {
         return memoRepository.findMemoAndMemoImageUrlsById(memoId).orElseThrow(
                 () -> new GlobalErrorException(MemoErrorCode.MEMO_NOT_FOUND)
@@ -87,5 +92,10 @@ public class MemoSearchService {
     @Transactional(readOnly = true)
     public List<MemoImage> findMemoImagesByMemoId(Long memoId) {
         return memoImageRepository.findByMemo_Id(memoId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> findMemoImageUrlsByMemoIds(List<Long> memoIds) {
+        return memoImageRepository.findMemoImageUrlsByMemoIds(memoIds);
     }
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/pet/domain/Pet.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/pet/domain/Pet.java
@@ -70,4 +70,14 @@ public class Pet extends DateAuditable {
                 .species(species)
                 .feed(feed).build();
     }
+
+    public void updatePet(Pet pet) {
+        this.petName = pet.getPetName();
+        this.species = pet.getSpecies();
+        this.gender = pet.getGender();
+        this.neutered = pet.isNeutered();
+        this.birthdate = pet.getBirthdate();
+        this.petProfileImg = pet.getPetProfileImg();
+        this.feed = pet.getFeed();
+    }
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/pet/dto/PetInfoRes.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/pet/dto/PetInfoRes.java
@@ -9,6 +9,7 @@ import org.springframework.util.StringUtils;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Dto(name = "pet")
@@ -36,7 +37,7 @@ public class PetInfoRes {
             return new PetSummaryInfo(
                     pet.getId(),
                     pet.getPetName(),
-                    pet.getPetProfileImg()
+                    Objects.toString(pet.getPetProfileImg(), "")
             );
         }
     }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/pet/dto/PetSaveReq.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/pet/dto/PetSaveReq.java
@@ -31,8 +31,10 @@ public class PetSaveReq {
     private LocalDate birthdate;
     @Schema(description = "반려동물 프로필 이미지", nullable = true)
     private String profileImg;
+    @Schema(description = "반려동물 사료 정보", nullable = true)
+    private String feed;
 
-    public Pet toPetEntity() {
+    public Pet toEntity() {
         return Pet.builder()
                 .petName(petName)
                 .species(species)
@@ -40,6 +42,7 @@ public class PetSaveReq {
                 .neutered(neutralization)
                 .birthdate(birthdate)
                 .petProfileImg(StringUtils.hasText(profileImg) ? profileImg : null)
+                .feed(StringUtils.hasText(feed) ? feed : null)
                 .build();
     }
 }

--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/pet/service/PetDeleteService.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/pet/service/PetDeleteService.java
@@ -1,0 +1,19 @@
+package kr.co.fitapet.domain.domains.pet.service;
+
+import kr.co.fitapet.common.annotation.DomainService;
+import kr.co.fitapet.domain.domains.pet.repository.PetRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@DomainService
+@RequiredArgsConstructor
+public class PetDeleteService {
+    private final PetRepository petRepository;
+
+    @Transactional
+    public void deletePet(Long petId) {
+        petRepository.deleteById(petId);
+    }
+}

--- a/fitapet-infra/src/main/java/kr/co/fitapet/infra/client/s3/NcpObjectStorageService.java
+++ b/fitapet-infra/src/main/java/kr/co/fitapet/infra/client/s3/NcpObjectStorageService.java
@@ -24,6 +24,7 @@ public class NcpObjectStorageService {
         List<String> nonImmutablePaths = new ArrayList<>(paths);
 
         nonImmutablePaths.replaceAll(path -> path.replace("https://" + config.getS3().bucket() + ".kr.object.ncloudstorage.com/", ""));
+        log.info("nonImmutablePaths: {}", nonImmutablePaths);
         List<DeleteObjectsRequest.KeyVersion> keys = nonImmutablePaths.stream().map(DeleteObjectsRequest.KeyVersion::new).toList();
 
         try {

--- a/fitapet-infra/src/main/java/kr/co/fitapet/infra/common/event/ObjectStorageEventHandler.java
+++ b/fitapet-infra/src/main/java/kr/co/fitapet/infra/common/event/ObjectStorageEventHandler.java
@@ -1,0 +1,29 @@
+package kr.co.fitapet.infra.common.event;
+
+import kr.co.fitapet.infra.client.s3.NcpObjectStorageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ObjectStorageEventHandler {
+    private final NcpObjectStorageService objectStorageService;
+
+    /**
+     * Object Storage에 저장된 이미지를 삭제합니다.
+     * <br/>
+     * {@link ObjectStorageImageDeleteEvent}를 받아서 Object Storage에 저장된 이미지를 삭제합니다.
+     * <br/>
+     * 해당 이벤트는 트랜잭션 내에서 실행되지 않습니다.
+     * @param event {@link ObjectStorageImageDeleteEvent}
+     */
+    @TransactionalEventListener
+    public void handleObjectStorageImageDeleteEvent(ObjectStorageImageDeleteEvent event) {
+        log.info("handleObjectStorageImageDeleteEvent: {}", event);
+        objectStorageService.deleteObjects(event.imageUrls());
+        log.info("Successfully deleted images from Object Storage");
+    }
+}

--- a/fitapet-infra/src/main/java/kr/co/fitapet/infra/common/event/ObjectStorageImageDeleteEvent.java
+++ b/fitapet-infra/src/main/java/kr/co/fitapet/infra/common/event/ObjectStorageImageDeleteEvent.java
@@ -1,0 +1,14 @@
+package kr.co.fitapet.infra.common.event;
+
+import java.util.List;
+
+/**
+ * Object Storage Image Delete Event를 위한 Object
+ */
+public record ObjectStorageImageDeleteEvent(
+        List<String> imageUrls
+) {
+    public static ObjectStorageImageDeleteEvent valueOf(List<String> imageUrls) {
+        return new ObjectStorageImageDeleteEvent(imageUrls);
+    }
+}


### PR DESCRIPTION
## 작업 이유
- 반려동물 수정/삭제 기능 구현
- 사용자가 설정한 기존 이름 반환

## 작업 사항
### 1️⃣ 기존 반려동물 API url 변경 (`/users/{user_id}` 제거)
- 반려동물 등록: `/api/v2/users/{user_id}/pets` → `/api/v2/pets`
- 반려동물 요약 정보: `/api/v2/users/{user_id}/pets/summary` → `/api/v2/pets/summary`
- 관리 중인 반려동물 정보: `/api/v2/users/{user_id}/pets` → `/api/v2/pets`

<br/>

### 2️⃣ 반려동물 요약 정보 리스트 조회 시, `imageUrl` null 반환 변경

<div align="center" style="width:50px">
   <img src="https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/fe6e24e6-6367-42a1-869e-748c1bad2b62" width='400'/>
</div>

- 제가 여기서 반려동물 프로필 이미지가 없으면 null을 반환하고 있더라구요. 수정해뒀습니다.

<br/>

### 3️⃣ 사용자 설정 이름 반환

<div align="center">
   <img src="https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/bbc095eb-9dc4-4546-af51-c745dcf9ee89" width='600'/>
</div>

- 요청: `GET /api/v2/accounts/{user_id}/name`
   - 요청자는 로그인된 유저여야 합니다.
   - `user_id`: 조회하려는 user의 pk
   - 1번 유저가 3번 유저 정보를 조회하고 싶으면 user_id는 3이 됩니다.
- 응답
   ```json
   {
       "status": "success",
       "data": {
           "name": "사용자 설정 이름(별명X)"
       }
   }
   ```


<br/>

### 4️⃣ 반려동물 정보 조회 (수정 뷰 전용)

<div align="center" style="width:50px">
   <img src="https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/46d18b20-9508-4dfa-ad7e-8d0762596ffa" width='400'/>
</div>

- 요청: `GET /api/v2/pets/{pet_id}`
  - 요청자는 반려동물의 마스터 권한을 가지고 있어야 합니다.
- 응답
   ```json
   {
       "status": "success",
       "data": {
           "pet": {
               "id": 9,
               "petName": "",
               "petProfileImage": "",
               "gender": "MALE", # MALE or FEMALE
               "neutered": false,
               "birthdate": "yyyy-MM-dd",
               "species": "",
               "feed": ""
           }
       }
   }
   ```

**🟡 예시 응답**

<div align="center" >
   <img src="https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/557be907-4300-421e-b99c-71ff682a2a17" width='700'/>
</div>

<br/>

### 5️⃣ 반려동물 정보 수정
- 요청: `PUT /api/v2/pets/{pet_id}`
  - 요청자는 반려동물의 마스터 권한을 가지고 있어야 합니다.
  - `feed`와 `profileImg`은 없으면 null을 허용합니다. (없으면 필드를 아예 제외하거나 null 송신. 빈 문자열 보내지 말 것)
  - 그 외 모든 필드는 null 및 빈 문자열을 허용하지 않습니다.
  - 입력 문자열 제한은 회의록에 나온 그대로입니다. (but, 아직 적용이 덜 되어 있습니다..)
   ```json
   {
       "petName": "반려동물 이름",
       "species": "반려동물 종",
       "gender": "성별(MALE/FEMALE)",
       "neutralization": true, # true or false
       "birthdate": "yyyy-MM-dd",
       "profileImg": null, # 혹은 아예 필드 생략. 있으면 url
       "feed": "사료"
   }
   ```

- 반려동물 생성과 완전 동일한 요청 포맷이라 어렵지 않으실 거예요.

**🟡 예시 응답**

<div align="center" >
   <img src="https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/b534f679-993b-4005-a3a0-4b768ab23473" width='700'/>
</div>


<br/>

### 6️⃣ 반려동물 삭제

- 요청: `DELETE /api/v2/pets/{pet_id}`
  - 반려동물과 관련된 모든 정보를 제거합니다. (케어, 일정, 기록, 매니저)
  - 반려동물 프로필 사진과 기록에 등록했던 모든 사진도 Object Storage에서 제거합니다.
  - 반려동물과 관련하여 push notification을 받은 정보들은 제거하지 않습니다. (알림 로그 유지)

***⚠️ 수정될 부분***
> 알고는 있어야 하나, api 스펙이 변경된다고 해서 따로 대응할 작업은 없을 겁니다.

<div align="center" >
   <img src="https://github.com/KCY-Fit-a-Pet/fit-a-pet-server/assets/96044622/cfb15428-03fe-4bed-bd61-22ae3357a1f4" width='600'/>
</div>

- 관리자 초대 데이터 관리 방법이 바뀌어야 하는 관계로 아직은 초대 정보가 삭제되지 않습니다.


## 이슈 연결
close #105 