### PR TITLE
🔥 CD pipeline 수정 및 QEntity 종속 경로 변경

### DIFF
--- a/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/invitation/repository/ManagerManagerInvitationQueryDslRepositoryDsl.java
+++ b/fitapet-domain/src/main/java/kr/co/fitapet/domain/domains/invitation/repository/ManagerManagerInvitationQueryDslRepositoryDsl.java
@@ -1,7 +1,7 @@
 package kr.co.fitapet.domain.domains.invitation.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import kr.co.fitapet.domain.domains.invitation.domain.QInvitation;
+import kr.co.fitapet.domain.domains.invitation.domain.QManagerInvitation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class ManagerManagerInvitationQueryDslRepositoryDsl implements ManagerInvitationQueryDslRepository {
     private final JPAQueryFactory queryFactory;
-    private final QInvitation invitation = QInvitation.invitation;
+    private final QManagerInvitation qManagerInvitation = QManagerInvitation.managerInvitation;
 
 }


### PR DESCRIPTION
## 작업 이유
- cd pipeline 오작동

## 작업 사항
- json 경로 수정
- QueryDsl 때문에 컴파일 실패
- 이번에도 안 되면 수동으로 올리고, 다음 커밋 때 손 보겠습니다.

## 이슈 연결
